### PR TITLE
p1: add lib/aur.sh; update README implementation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,14 +42,23 @@ controls, security policies, or acceptable use rules.
 A three-layer architecture: Python orchestration (`orchestrator/`), distro
 abstraction (`distros/`), and Bash execution units (`lib/*.sh`, `bash/*.sh`).
 
-- [ ] Python orchestration layer — subprocess management, state tracking,
+- [x] Python orchestration layer — subprocess management, state tracking,
       cancellation with automatic rollback, audit log, config snapshots
-- [ ] Distro abstraction layer — Arch/CachyOS driver; stub for future Debian
-- [ ] Bash library modules — logging, environment detection, AUR helper,
-      package installation, pcscd service, certificate download and import,
-      browser/NSS discovery, PKCS11 registration, post-install verification
-- [ ] Install and uninstall workflows — `cac_setup.py` + `cac_uninstall.py`;
-      uninstall is fully symmetric and idempotent
+- [x] Distro abstraction layer — Arch/CachyOS driver; stub for future Debian
+- Bash library modules:
+  - [x] `lib/log.sh` — color-coded terminal output + persistent log file
+  - [x] `lib/detect.sh` — root/user/env validation, tool checks, module unload
+  - [x] `lib/aur.sh` — AUR helper detection (`paru`/`yay`), non-root install wrapper
+  - [ ] `lib/packages.sh` — pacman sync + package installation
+  - [ ] `lib/opensc_conf.sh` — force CAC driver in `/etc/opensc/opensc.conf`
+  - [ ] `lib/service.sh` — enable + start `pcscd.socket`
+  - [ ] `lib/certs.sh` — DoD certificate bundle download + checksum validation
+  - [ ] `lib/browser.sh` — browser detection, NSS database discovery
+  - [ ] `lib/import.sh` — `certutil` certificate import into all NSS databases
+  - [ ] `lib/pkcs11.sh` — `modutil` PKCS11 module registration
+  - [ ] `lib/verify.sh` — post-install verification
+- [ ] Install and uninstall entry points — `cac_setup.py`, `cac_uninstall.py`,
+      `bash/install.sh`, `bash/uninstall.sh`
 - [ ] Testing suite — BATS unit tests with mocked system commands; Python
       `unittest` for the orchestration layer
 - [ ] User documentation — `README.md`, `KNOWN_ISSUES.md`

--- a/lib/aur.sh
+++ b/lib/aur.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# lib/aur.sh — AUR helper detection and package installation
+#
+# Provides: detect_aur_helper, aur_install
+#
+# AUR helpers (paru, yay) MUST NOT be run as root. aur_install drops to
+# $REAL_USER via `sudo -H -u "$REAL_USER"` for every invocation.
+# Used for AUR-only browsers: google-chrome, microsoft-edge-stable-bin, brave-bin.
+#
+# No set -euo pipefail — inherited from bash/install.sh or bash/uninstall.sh.
+
+_AUR_HELPER=""
+
+detect_aur_helper() {
+    # Populate $_AUR_HELPER with the first available AUR helper.
+    # Preference: paru (CachyOS default) then yay.
+    if command -v paru > /dev/null 2>&1; then
+        _AUR_HELPER="paru"
+        log_info "AUR helper: paru"
+    elif command -v yay > /dev/null 2>&1; then
+        _AUR_HELPER="yay"
+        log_info "AUR helper: yay"
+    else
+        _AUR_HELPER=""
+        log_warn "No AUR helper found. AUR packages (Google Chrome, Edge, Brave) cannot be installed."
+        log_warn "Install paru or yay, then re-run if those browsers are needed."
+    fi
+}
+
+aur_install() {
+    # Install an AUR package as $REAL_USER (AUR helpers refuse to run as root).
+    # Returns 1 gracefully if no AUR helper is available — non-fatal by design,
+    # since AUR browsers are optional. Failures are logged as warnings.
+    #
+    # Usage: aur_install <package_name>
+    local pkg="$1"
+    if [[ -z "$_AUR_HELPER" ]]; then
+        log_warn "Cannot install AUR package $pkg: no AUR helper available."
+        return 1
+    fi
+    log_info "Installing AUR package: $pkg (as $REAL_USER)"
+    local s=0
+    sudo -H -u "$REAL_USER" "$_AUR_HELPER" -S --noconfirm "$pkg" >> "$_CAC_LOG_FILE" 2>&1 || s=$?
+    if [[ $s -ne 0 ]]; then
+        log_warn "Failed to install AUR package: $pkg (non-fatal, continuing)"
+        return $s
+    fi
+    log_success "AUR package installed: $pkg"
+    return 0
+}


### PR DESCRIPTION
lib/aur.sh (Step 3):
- detect_aur_helper: prefers paru (CachyOS default), falls back to yay, warns if neither is found
- aur_install: drops privilege to $REAL_USER via sudo -H -u before invoking the AUR helper (AUR helpers refuse to run as root); returns 1 gracefully when no helper is available (AUR browsers are optional)

README.md:
- Expanded Phase 1 checklist to show per-lib-file status
- Marked orchestrator/, distros/, log.sh, detect.sh, and aur.sh complete

bash -n: syntax OK