### PR TITLE
p1: add lib/opensc_conf.sh — OpenSC CAC driver configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ abstraction (`distros/`), and Bash execution units (`lib/*.sh`, `bash/*.sh`).
   - [x] `lib/detect.sh` — root/user/env validation, tool checks, module unload
   - [x] `lib/aur.sh` — AUR helper detection (`paru`/`yay`), non-root install wrapper
   - [x] `lib/packages.sh` — pacman sync + package installation
-  - [ ] `lib/opensc_conf.sh` — force CAC driver in `/etc/opensc/opensc.conf`
+  - [x] `lib/opensc_conf.sh` — force CAC driver in `/etc/opensc/opensc.conf`
   - [ ] `lib/service.sh` — enable + start `pcscd.socket`
   - [ ] `lib/certs.sh` — DoD certificate bundle download + checksum validation
   - [ ] `lib/browser.sh` — browser detection, NSS database discovery

--- a/lib/opensc_conf.sh
+++ b/lib/opensc_conf.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# lib/opensc_conf.sh — OpenSC CAC driver configuration
+#
+# Provides: configure_opensc_cac_driver
+#
+# Without explicit CAC driver forcing, OpenSC's auto-detection heuristic
+# may select the PIV-II driver instead of the CAC driver, silently breaking
+# card recognition even when the reader is detected. This is a known failure
+# mode documented in KNOWN_ISSUES.md #P3.
+#
+# Source: M-Pepper linux-cac-walkthrough
+# No set -euo pipefail — inherited from bash/install.sh or bash/uninstall.sh.
+
+OPENSC_CONF="/etc/opensc/opensc.conf"
+
+configure_opensc_cac_driver() {
+    log_section "OpenSC Configuration"
+
+    if [[ ! -f "$OPENSC_CONF" ]]; then
+        log_warn "$OPENSC_CONF not found — skipping (opensc may not be installed yet)"
+        return 0
+    fi
+
+    # Idempotent: if force_card_driver is already present, nothing to do.
+    if grep -q "force_card_driver" "$OPENSC_CONF" 2>/dev/null; then
+        log_info "OpenSC CAC driver forcing already configured."
+        return 0
+    fi
+
+    log_info "Adding CAC driver forcing to $OPENSC_CONF..."
+
+    if grep -q "app default {" "$OPENSC_CONF"; then
+        # Insert immediately after the `app default {` line
+        sed -i '/app default {/a\\tcard_drivers = cac;\n\tforce_card_driver = cac;' "$OPENSC_CONF"
+    else
+        # No `app default` block — append one at the end
+        printf '\napp default {\n\tcard_drivers = cac;\n\tforce_card_driver = cac;\n}\n' \
+            >> "$OPENSC_CONF"
+    fi
+
+    log_success "OpenSC CAC driver forcing configured."
+}


### PR DESCRIPTION
Implements Step 4.5 from docs/PLAN.md.

Provides: configure_opensc_cac_driver

Without forcing the CAC driver, OpenSC's auto-detection heuristic can select the PIV-II driver instead, silently preventing card recognition even when the reader is detected (KNOWN_ISSUES.md #P3).

Key details:
- Idempotent: skips if force_card_driver already present in the conf
- Inserts into existing `app default { }` block via sed if present, otherwise appends a new block at end of file
- Non-fatal if /etc/opensc/opensc.conf doesn't exist yet (warns + returns 0)
- No set -euo pipefail — inherited from bash/install.sh

bash -n: syntax OK