### PR TITLE
p1: add lib/pkcs11.sh — PKCS11 module registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ abstraction (`distros/`), and Bash execution units (`lib/*.sh`, `bash/*.sh`).
   - [x] `lib/certs.sh` — DoD certificate bundle download + checksum validation
   - [x] `lib/browser.sh` — browser detection, NSS database discovery
   - [x] `lib/import.sh` — `certutil` certificate import into all NSS databases
-  - [ ] `lib/pkcs11.sh` — `modutil` PKCS11 module registration
+  - [x] `lib/pkcs11.sh` — `modutil` PKCS11 module registration
   - [ ] `lib/verify.sh` — post-install verification
 - [ ] Install and uninstall entry points — `cac_setup.py`, `cac_uninstall.py`,
       `bash/install.sh`, `bash/uninstall.sh`

--- a/lib/pkcs11.sh
+++ b/lib/pkcs11.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# lib/pkcs11.sh — OpenSC PKCS11 module registration in NSS databases
+#
+# Provides: cleanup_legacy_pkcs11, register_pkcs11_in_db, register_pkcs11_all
+#
+# Uses modutil (not certutil) for PKCS11 provider module records in pkcs11.txt.
+# Both tools come from the nss package; certutil handles certificate records,
+# modutil handles PKCS11 module records.
+#
+# NSS OWNERSHIP RULE (enforced without exception):
+# All modutil calls MUST run as $REAL_USER via `sudo -H -u "$REAL_USER"`.
+# See KNOWN_ISSUES.md #P6.
+#
+# OPENSC_PKCS11_LIB is a local alias for the injected PKCS11_LIB variable.
+# It is declared readonly at the top of this file per PLAN.md convention;
+# all other lib files use $PKCS11_LIB directly.
+#
+# pkcs11-register note: silently misses Firefox on CachyOS because it
+# hardcodes ~/.mozilla/firefox as the profile search path. The modutil
+# calls above handle Firefox correctly. pkcs11-register is called as
+# a supplemental best-effort step only. See KNOWN_ISSUES.md #P5.
+#
+# No set -euo pipefail — inherited from bash/install.sh or bash/uninstall.sh.
+
+# Local alias for the Python-injected PKCS11_LIB environment variable.
+# Guard for safe BATS re-sourcing.
+[[ -v OPENSC_PKCS11_LIB  ]] || readonly OPENSC_PKCS11_LIB="${PKCS11_LIB}"
+[[ -v PKCS11_MODULE_NAME ]] || readonly PKCS11_MODULE_NAME="CAC Module"
+
+cleanup_legacy_pkcs11() {
+    # Remove stale cackey/coolkey entries before registering OpenSC.
+    # A broken legacy entry pointing to a missing library is found by the
+    # browser first, causing silent auth failure. See KNOWN_ISSUES.md #P2.
+    #
+    # Usage: cleanup_legacy_pkcs11 <db_dir>
+    local db_dir="$1"
+    local legacy_name
+    for legacy_name in "CAC Module" "CACKey" "coolkey" "libcoolkeypk11"; do
+        if sudo -H -u "$REAL_USER" modutil \
+                -dbdir "sql:$db_dir" -list 2>/dev/null | grep -qi "$legacy_name"; then
+            log_info "Removing legacy PKCS11 entry '$legacy_name' from: $db_dir"
+            sudo -H -u "$REAL_USER" modutil \
+                -dbdir "sql:$db_dir" \
+                -delete "$legacy_name" \
+                -force >> "$_CAC_LOG_FILE" 2>&1 || true
+        fi
+    done
+}
+
+register_pkcs11_in_db() {
+    # Register the OpenSC PKCS11 module in the given NSS database.
+    # Idempotent: skips if already registered. Non-fatal on modutil error.
+    #
+    # Usage: register_pkcs11_in_db <db_dir>
+    local db_dir="$1"
+
+    cleanup_legacy_pkcs11 "$db_dir"
+
+    # Check if already registered — must run as $REAL_USER (NSS ownership rule)
+    if sudo -H -u "$REAL_USER" modutil \
+            -dbdir "sql:$db_dir" -list 2>/dev/null | grep -qi "opensc-pkcs11"; then
+        log_info "OpenSC module already registered in: $db_dir"
+        return 0
+    fi
+
+    log_info "Registering OpenSC PKCS11 module in: $db_dir"
+    # -force suppresses the interactive "please restart your browser" prompt
+    local s=0
+    sudo -H -u "$REAL_USER" modutil \
+        -dbdir "sql:$db_dir" \
+        -add "$PKCS11_MODULE_NAME" \
+        -libfile "$OPENSC_PKCS11_LIB" \
+        -force >> "$_CAC_LOG_FILE" 2>&1 || s=$?
+
+    if [[ $s -ne 0 ]]; then
+        log_warn "modutil returned $s for: $db_dir (non-fatal — see log)"
+        return $s
+    fi
+
+    log_success "Registered PKCS11 module in: $db_dir"
+    echo "ACTION:pkcs11_register|$db_dir|$PKCS11_MODULE_NAME|$OPENSC_PKCS11_LIB"
+    echo "STATE:pkcs11_registered_in+=$db_dir"
+}
+
+register_pkcs11_all() {
+    log_section "PKCS11 Module Registration"
+    log_info "PKCS11 library: $OPENSC_PKCS11_LIB"
+
+    if [[ ! -f "$OPENSC_PKCS11_LIB" ]]; then
+        log_error "OpenSC PKCS11 library not found: $OPENSC_PKCS11_LIB"
+        log_error "Ensure opensc is installed: pacman -S opensc"
+        exit 1
+    fi
+
+    local db_dir
+    for db_dir in "${NSS_DATABASES[@]}"; do
+        register_pkcs11_in_db "$db_dir"
+    done
+
+    # pkcs11-register as supplemental best-effort step.
+    # Handles ~/.pki/nssdb but silently misses Firefox on CachyOS
+    # (searches ~/.mozilla/firefox, not ~/.config/mozilla/firefox).
+    # The modutil calls above already cover Firefox correctly.
+    if command -v pkcs11-register > /dev/null 2>&1; then
+        log_info "Running pkcs11-register (supplemental — non-zero exit expected on CachyOS for Firefox)..."
+        sudo -H -u "$REAL_USER" pkcs11-register >> "$_CAC_LOG_FILE" 2>&1 || true
+        log_info "pkcs11-register step complete."
+    fi
+
+    log_success "PKCS11 registration phase complete."
+}


### PR DESCRIPTION
Implements Step 9 from docs/PLAN.md.

Provides: cleanup_legacy_pkcs11, register_pkcs11_in_db, register_pkcs11_all.

Key details:
- OPENSC_PKCS11_LIB declared as readonly alias for injected PKCS11_LIB per PLAN.md convention; guarded with [[ -v ]] for BATS re-sourcing
- cleanup_legacy_pkcs11 removes stale cackey/coolkey/CACKey entries before registering OpenSC — broken legacy entries cause the browser to find the missing library first and fail silently (KNOWN_ISSUES.md #P2)
- register_pkcs11_in_db is idempotent (checks for opensc-pkcs11 before adding); uses -force to suppress interactive browser-restart prompt
- NSS ownership rule enforced: all modutil calls run as $REAL_USER (KNOWN_ISSUES.md #P6)
- Emits ACTION:pkcs11_register and STATE:pkcs11_registered_in+= for Python audit log and state tracking
- pkcs11-register called as supplemental best-effort only — silently misses Firefox on CachyOS; modutil handles Firefox correctly (#P5)
- Fails fast if OPENSC_PKCS11_LIB file does not exist

bash -n: syntax OK