### PR TITLE
Add install/uninstall entry points and uninstall lib functions (Step 11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ abstraction (`distros/`), and Bash execution units (`lib/*.sh`, `bash/*.sh`).
   - [x] `lib/import.sh` — `certutil` certificate import into all NSS databases
   - [x] `lib/pkcs11.sh` — `modutil` PKCS11 module registration
   - [x] `lib/verify.sh` — post-install verification
-- [ ] Install and uninstall entry points — `cac_setup.py`, `cac_uninstall.py`,
+- [x] Install and uninstall entry points — `cac_setup.py`, `cac_uninstall.py`,
       `bash/install.sh`, `bash/uninstall.sh`
 - [ ] Testing suite — BATS unit tests with mocked system commands; Python
       `unittest` for the orchestration layer

--- a/bash/install.sh
+++ b/bash/install.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# bash/install.sh — CAC install execution unit
+#
+# Called by cac_setup.py via orchestrator/runner.py with --phase=<name>.
+# All distro-specific values arrive as environment variables from Python.
+# Do NOT add orchestration logic here — Python is the orchestrator.
+#
+# Usage (via Python):
+#   python orchestrator invokes: bash bash/install.sh --phase=<name>
+#
+# Developer standalone escape hatch (all phases, no Python):
+#   export PKCS11_LIB=/usr/lib/opensc-pkcs11.so PCSCD_UNIT=pcscd.socket \
+#          REAL_USER=$USER REAL_HOME=$HOME STATE_FILE=/var/lib/cac_for_linux_distros/state.json
+#   sudo bash bash/install.sh --phase=all
+#
+# No sourcing of set -euo pipefail by lib/*.sh — this file declares it for them.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHASE="${1:---phase=all}"
+
+for lib_file in log detect aur packages opensc_conf service certs browser import pkcs11 verify; do
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/lib/$lib_file.sh"
+done
+
+validate_env
+log_init
+
+case "$PHASE" in
+    --phase=preflight)
+        log_section "Phase 1: Pre-flight Checks"
+        detect_root
+        detect_real_user
+        detect_required_tools
+        check_browsers_closed
+        ;;
+
+    --phase=packages)
+        log_section "Phase 2: Package Installation"
+        detect_aur_helper
+        install_official_packages
+        verify_certutil
+        detect_post_install_tools
+        ;;
+
+    --phase=opensc-conf)
+        log_section "Phase 2.5: OpenSC Configuration"
+        configure_opensc_cac_driver
+        ;;
+
+    --phase=service)
+        log_section "Phase 3: Smart Card Daemon"
+        detect_conflicting_modules
+        record_pcscd_state
+        enable_pcscd
+        ;;
+
+    --phase=certs)
+        log_section "Phase 4: Certificate Download"
+        download_certs
+        validate_cert_bundle
+        extract_certs
+        ;;
+
+    --phase=import)
+        log_section "Phase 5: Browser and Certificate Setup"
+        discover_databases
+        import_all_certs
+        ;;
+
+    --phase=pkcs11)
+        log_section "Phase 6: PKCS11 Module Registration"
+        register_pkcs11_all
+        ;;
+
+    --phase=verify)
+        log_section "Phase 7: Cleanup and Verification"
+        cleanup_certs
+        run_verification
+        configure_horizon_symlink
+        ;;
+
+    --phase=certs-only)
+        # Snapshot restore: import only, no packages/services
+        import_all_certs
+        ;;
+
+    --phase=pkcs11-only)
+        # Snapshot restore: PKCS11 only, no packages/services
+        register_pkcs11_all
+        ;;
+
+    --phase=all | all)
+        # Developer escape hatch: run all phases without Python.
+        # REQUIRES: export PKCS11_LIB PCSCD_UNIT REAL_USER REAL_HOME STATE_FILE before running.
+        # See tests/helpers/set_test_env.sh for a test wrapper.
+        log_section "CAC for Linux Distros — Setup (standalone mode)"
+        detect_root
+        detect_real_user
+        detect_required_tools
+        check_browsers_closed
+        detect_aur_helper
+        install_official_packages
+        verify_certutil
+        detect_post_install_tools
+        configure_opensc_cac_driver
+        detect_conflicting_modules
+        record_pcscd_state
+        enable_pcscd
+        download_certs
+        validate_cert_bundle
+        extract_certs
+        discover_databases
+        import_all_certs
+        register_pkcs11_all
+        cleanup_certs
+        run_verification
+        configure_horizon_symlink
+        ;;
+
+    *)
+        echo "[ERROR] Unknown phase: $PHASE" >&2
+        exit 1
+        ;;
+esac

--- a/bash/uninstall.sh
+++ b/bash/uninstall.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# bash/uninstall.sh — CAC uninstall execution unit
+#
+# Called by cac_uninstall.py via orchestrator/runner.py with --phase=<name>.
+# All distro-specific values arrive as environment variables from Python.
+# Do NOT add orchestration logic here — Python is the orchestrator.
+#
+# Usage (via Python):
+#   python orchestrator invokes: bash bash/uninstall.sh --phase=<name>
+#
+# Developer standalone escape hatch (all phases, no Python):
+#   export PKCS11_LIB=/usr/lib/opensc-pkcs11.so PCSCD_UNIT=pcscd.socket \
+#          REAL_USER=$USER REAL_HOME=$HOME STATE_FILE=/var/lib/cac_for_linux_distros/state.json
+#   sudo bash bash/uninstall.sh --phase=all
+#
+# No sourcing of set -euo pipefail by lib/*.sh — this file declares it for them.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHASE="${1:---phase=all}"
+
+for lib_file in log detect service browser import pkcs11 packages verify; do
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/lib/$lib_file.sh"
+done
+
+validate_env
+log_init
+
+case "$PHASE" in
+    --phase=preflight)
+        detect_root
+        detect_real_user
+        check_browsers_closed
+        ;;
+
+    --phase=pkcs11)
+        unregister_pkcs11_all
+        ;;
+
+    --phase=certs)
+        remove_all_certs
+        ;;
+
+    --phase=service)
+        disable_pcscd
+        ;;
+
+    --phase=packages)
+        remove_smart_card_packages
+        ;;
+
+    --phase=cleanup)
+        remove_state_and_logs
+        ;;
+
+    --phase=verify)
+        run_uninstall_verification
+        ;;
+
+    --phase=certs-only)
+        # Targeted restore: remove certs only, no packages/services
+        remove_all_certs
+        ;;
+
+    --phase=pkcs11-only)
+        # Targeted restore: remove PKCS11 only, no packages/services
+        unregister_pkcs11_all
+        ;;
+
+    --phase=all | all)
+        # Developer escape hatch: run all phases without Python.
+        # REQUIRES: export PKCS11_LIB PCSCD_UNIT REAL_USER REAL_HOME STATE_FILE before running.
+        log_section "CAC for Linux Distros — Uninstall (standalone mode)"
+        detect_root
+        detect_real_user
+        check_browsers_closed
+        unregister_pkcs11_all
+        remove_all_certs
+        disable_pcscd
+        remove_smart_card_packages
+        remove_state_and_logs
+        run_uninstall_verification
+        ;;
+
+    *)
+        echo "[ERROR] Unknown phase: $PHASE" >&2
+        exit 1
+        ;;
+esac

--- a/cac_setup.py
+++ b/cac_setup.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# cac_setup.py — CAC for Linux Distros install entry point
+#
+# Usage: sudo python3 cac_setup.py
+# All browsers must be closed before running.
+import sys
+import os
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from orchestrator.setup_flow import run_setup
+from distros.detect import detect_distro
+
+
+def main() -> None:
+    if os.geteuid() != 0:
+        print("[ERROR] Run with sudo: sudo python3 cac_setup.py", file=sys.stderr)
+        sys.exit(86)
+
+    sudo_user = os.environ.get("SUDO_USER", "")
+    if not sudo_user:
+        print("[ERROR] SUDO_USER not set. Run: sudo python3 cac_setup.py", file=sys.stderr)
+        sys.exit(86)
+
+    try:
+        distro_info, driver = detect_distro()
+    except RuntimeError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"[INFO]  Detected: {distro_info.pretty_name} ({distro_info.arch})")
+    print(f"[INFO]  User: {sudo_user}")
+    run_setup(driver=driver, sudo_user=sudo_user)
+
+
+if __name__ == "__main__":
+    main()

--- a/cac_uninstall.py
+++ b/cac_uninstall.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# cac_uninstall.py — CAC for Linux Distros uninstall entry point
+#
+# Usage: sudo python3 cac_uninstall.py
+# All browsers must be closed before running.
+import sys
+import os
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from orchestrator.uninstall_flow import run_uninstall
+from orchestrator.state import InstallState
+from distros.detect import detect_distro
+
+
+def main() -> None:
+    if os.geteuid() != 0:
+        print("[ERROR] Run with sudo: sudo python3 cac_uninstall.py", file=sys.stderr)
+        sys.exit(86)
+
+    try:
+        state = InstallState.load()
+    except FileNotFoundError:
+        print("[ERROR] No state file at /var/lib/cac_for_linux_distros/state.json")
+        print("        If installed manually, see README.md for manual uninstall steps")
+        sys.exit(1)
+
+    _, driver = detect_distro()
+    run_uninstall(state=state, driver=driver)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # lib/detect.sh — Environment validation for cac_for_linux_distros
 #
+# Provides: validate_env, detect_root, detect_real_user, detect_required_tools,
+#           detect_post_install_tools, detect_conflicting_modules, detect_to_json,
+#           _state_read_list, remove_state_and_logs
+#
 # OS/arch detection is handled by Python (distros/detect.py). All distro-specific
 # values (PKCS11_LIB, PCSCD_UNIT, REAL_USER, REAL_HOME, STATE_FILE) arrive as
 # environment variables injected by the Python orchestrator before every Bash
@@ -99,4 +103,56 @@ detect_to_json() {
     # Python calls this to confirm Bash sees the injected environment correctly.
     printf '{"arch":"%s","user":"%s","pkcs11_lib":"%s"}\n' \
         "$(uname -m)" "${REAL_USER:-}" "${PKCS11_LIB:-}"
+}
+
+_state_read_list() {
+    # Usage: _state_read_list <json_key>
+    # Reads a JSON array from $STATE_FILE, printing one item per line.
+    # Silent no-op if STATE_FILE is missing, unreadable, or the key is absent.
+    python3 -c "
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    [print(i) for i in d.get(sys.argv[2], []) if i]
+except Exception:
+    pass
+" "$STATE_FILE" "$1" 2>/dev/null || true
+}
+
+remove_state_and_logs() {
+    # Remove Horizon symlinks, log files, and the state directory.
+    # Must be called LAST in the uninstall sequence — state is gone after this.
+    # Horizon symlinks are identified by the constants in lib/verify.sh (sourced
+    # before this function is invoked).
+    log_section "Cleanup: State and Logs"
+
+    # Remove Horizon symlinks if they are symlinks created by this tool
+    local link
+    for link in "${VMWARE_HORIZON_PKCS11:-}" "${OMNISSA_HORIZON_PKCS11:-}"; do
+        [[ -z "$link" ]] && continue
+        if [[ -L "$link" ]]; then
+            rm -f "$link"
+            log_success "Removed Horizon symlink: $link"
+            echo "ACTION:horizon_symlink_removed|$link"
+        fi
+    done
+
+    # Remove log files
+    local log_file
+    for log_file in /var/log/cac_for_linux_distros_*.log; do
+        [[ -f "$log_file" ]] || continue
+        rm -f "$log_file"
+        log_success "Removed log: $log_file"
+    done
+
+    # Remove state directory last (can no longer read state after this)
+    local state_dir="/var/lib/cac_for_linux_distros"
+    if [[ -d "$state_dir" ]]; then
+        rm -rf "$state_dir"
+        log_success "Removed state directory: $state_dir"
+    else
+        log_info "State directory already absent: $state_dir"
+    fi
+
+    log_success "Cleanup complete."
 }

--- a/lib/import.sh
+++ b/lib/import.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # lib/import.sh — DoD certificate import into NSS databases
 #
-# Provides: import_certs_into_db, import_all_certs
+# Provides: import_certs_into_db, import_all_certs, remove_all_certs
 #
 # NSS OWNERSHIP RULE (enforced without exception):
 # All certutil calls MUST run as $REAL_USER via `sudo -H -u "$REAL_USER"`.
@@ -97,4 +97,48 @@ import_all_certs() {
     done
 
     log_success "Certificate import phase complete."
+}
+
+remove_all_certs() {
+    # Remove DoD CA certificates from all NSS databases listed in state.
+    # Reads nss_databases and imported_cert_nicknames from $STATE_FILE via
+    # _state_read_list (defined in lib/detect.sh).
+    # Uses exact nickname match from state — safe to run multiple times (idempotent).
+    # Must run certutil as $REAL_USER (NSS ownership rule).
+    log_section "Certificate Removal"
+
+    local nss_dbs=() nicknames=()
+    mapfile -t nss_dbs   < <(_state_read_list "nss_databases")
+    mapfile -t nicknames < <(_state_read_list "imported_cert_nicknames")
+
+    if [[ ${#nss_dbs[@]} -eq 0 ]] || [[ ${#nicknames[@]} -eq 0 ]]; then
+        log_info "No certificate removal entries found in state — nothing to do."
+        return 0
+    fi
+
+    local db_dir nick
+    for db_dir in "${nss_dbs[@]}"; do
+        [[ -z "$db_dir" ]] && continue
+        if [[ ! -d "$db_dir" ]]; then
+            log_info "NSS database absent (already removed?): $db_dir"
+            continue
+        fi
+        log_info "Removing certificates from: $db_dir"
+        local removed=0 skipped=0
+        for nick in "${nicknames[@]}"; do
+            [[ -z "$nick" ]] && continue
+            if sudo -H -u "$REAL_USER" certutil \
+                    -d "sql:$db_dir" -L -n "$nick" > /dev/null 2>&1; then
+                sudo -H -u "$REAL_USER" certutil \
+                    -d "sql:$db_dir" -D -n "$nick" >> "$_CAC_LOG_FILE" 2>&1 || true
+                (( removed++ ))
+            else
+                (( skipped++ ))
+            fi
+        done
+        log_success "  Removed $removed cert(s), skipped $skipped (already absent)"
+        echo "ACTION:certs_removed|$db_dir|count=$removed"
+    done
+
+    log_success "Certificate removal phase complete."
 }

--- a/lib/packages.sh
+++ b/lib/packages.sh
@@ -2,7 +2,7 @@
 # lib/packages.sh — Package installation for cac_for_linux_distros
 #
 # Provides: install_official_packages, is_package_installed, verify_certutil,
-#           emit_packages_state
+#           emit_packages_state, remove_smart_card_packages
 #
 # MAINTENANCE NOTE: REQUIRED_PACKAGES is also defined in distros/arch/config.py.
 # Both lists must be kept in sync. The Bash list is the executable authority;
@@ -80,4 +80,44 @@ emit_packages_state() {
     done
     local IFS=','
     echo "STATE:packages_installed=${installed[*]}"
+}
+
+remove_smart_card_packages() {
+    # Remove only smart-card-specific packages that were installed by this tool.
+    # Reads packages_installed from $STATE_FILE via _state_read_list (lib/detect.sh).
+    # Intersects with SMART_CARD_ONLY to avoid removing general utilities (wget, unzip).
+    # Uses `pacman -Rs` to also remove orphaned dependencies.
+    log_section "Package Removal"
+
+    # Packages this tool installed
+    local installed_by_tool=()
+    mapfile -t installed_by_tool < <(_state_read_list "packages_installed" \
+        | sed 's/=.*//')   # strip version suffixes (pkg=version → pkg)
+
+    # Packages safe to remove (smart-card-specific only; not wget/unzip/nss)
+    local smart_card_only=(pcsclite ccid opensc pcsc-tools)
+    local to_remove=()
+    local pkg
+    for pkg in "${smart_card_only[@]}"; do
+        if printf '%s\n' "${installed_by_tool[@]}" | grep -qx "$pkg"; then
+            if is_package_installed "$pkg"; then
+                to_remove+=("$pkg")
+            fi
+        fi
+    done
+
+    if [[ ${#to_remove[@]} -eq 0 ]]; then
+        log_info "No smart-card-specific packages to remove."
+        return 0
+    fi
+
+    log_info "Removing packages: ${to_remove[*]}"
+    local s=0
+    pacman -Rs --noconfirm "${to_remove[@]}" >> "$_CAC_LOG_FILE" 2>&1 || s=$?
+    if [[ $s -ne 0 ]]; then
+        log_warn "pacman -Rs returned $s — packages may have already been removed (non-fatal)"
+    else
+        log_success "Packages removed: ${to_remove[*]}"
+        echo "ACTION:packages_removed|${to_remove[*]}"
+    fi
 }

--- a/lib/pkcs11.sh
+++ b/lib/pkcs11.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # lib/pkcs11.sh — OpenSC PKCS11 module registration in NSS databases
 #
-# Provides: cleanup_legacy_pkcs11, register_pkcs11_in_db, register_pkcs11_all
+# Provides: cleanup_legacy_pkcs11, register_pkcs11_in_db, register_pkcs11_all,
+#           unregister_pkcs11_all
 #
 # Uses modutil (not certutil) for PKCS11 provider module records in pkcs11.txt.
 # Both tools come from the nss package; certutil handles certificate records,
@@ -108,4 +109,44 @@ register_pkcs11_all() {
     fi
 
     log_success "PKCS11 registration phase complete."
+}
+
+unregister_pkcs11_all() {
+    # Remove the OpenSC PKCS11 module from all NSS databases listed in state.
+    # Reads pkcs11_registered_in from $STATE_FILE via _state_read_list
+    # (defined in lib/detect.sh).
+    # Idempotent: skips databases where the module is already absent.
+    # Must run modutil as $REAL_USER (NSS ownership rule).
+    log_section "PKCS11 Module Unregistration"
+
+    local registered_dbs=()
+    mapfile -t registered_dbs < <(_state_read_list "pkcs11_registered_in")
+
+    if [[ ${#registered_dbs[@]} -eq 0 ]]; then
+        log_info "No PKCS11 registrations found in state — nothing to remove."
+        return 0
+    fi
+
+    local db_dir
+    for db_dir in "${registered_dbs[@]}"; do
+        [[ -z "$db_dir" ]] && continue
+        if [[ ! -d "$db_dir" ]]; then
+            log_info "NSS database absent (already removed?): $db_dir"
+            continue
+        fi
+        if sudo -H -u "$REAL_USER" modutil \
+                -dbdir "sql:$db_dir" -list 2>/dev/null | grep -qi "CAC Module"; then
+            log_info "Removing PKCS11 module from: $db_dir"
+            sudo -H -u "$REAL_USER" modutil \
+                -dbdir "sql:$db_dir" \
+                -delete "$PKCS11_MODULE_NAME" \
+                -force >> "$_CAC_LOG_FILE" 2>&1 || true
+            log_success "Removed PKCS11 module from: $db_dir"
+            echo "ACTION:pkcs11_unregister|$db_dir|$PKCS11_MODULE_NAME"
+        else
+            log_info "PKCS11 module not registered in: $db_dir (already removed)"
+        fi
+    done
+
+    log_success "PKCS11 unregistration phase complete."
 }

--- a/lib/verify.sh
+++ b/lib/verify.sh
@@ -3,7 +3,7 @@
 #
 # Provides: verify_pcscd, verify_pkcs11_registered, verify_certificates_imported,
 #           verify_card_reader, verify_card_objects, run_verification,
-#           configure_horizon_symlink
+#           configure_horizon_symlink, run_uninstall_verification
 #
 # NSS OWNERSHIP RULE (enforced without exception):
 # All certutil and modutil calls MUST run as $REAL_USER via `sudo -H -u "$REAL_USER"`.
@@ -137,6 +137,46 @@ run_verification() {
     else
         log_warn "Some checks failed — review: $_CAC_LOG_FILE"
         log_warn "A reboot may still resolve these issues."
+    fi
+}
+
+run_uninstall_verification() {
+    # Verify that the uninstall completed cleanly.
+    # Checks common NSS database locations directly (does not rely on $STATE_FILE,
+    # which may have been removed by remove_state_and_logs before this runs).
+    log_section "Uninstall Verification"
+    local issues=0
+
+    # Check common NSS database locations for lingering PKCS11 registration
+    local check_dbs=()
+    [[ -d "$REAL_HOME/.pki/nssdb" ]] && check_dbs+=("$REAL_HOME/.pki/nssdb")
+    local ff_db
+    while IFS= read -r ff_db; do
+        [[ -n "$ff_db" ]] && check_dbs+=("$(dirname "$ff_db")")
+    done < <(find "$REAL_HOME/.config/mozilla/firefox" \
+                  "$REAL_HOME/.mozilla/firefox" \
+                  -name cert9.db 2>/dev/null | grep -v Trash || true)
+
+    local db_dir
+    for db_dir in "${check_dbs[@]}"; do
+        if sudo -H -u "$REAL_USER" modutil \
+                -dbdir "sql:$db_dir" -list 2>/dev/null | grep -qi "CAC Module"; then
+            log_warn "  PKCS11 module still registered in: $db_dir"
+            (( issues++ ))
+        fi
+    done
+
+    # Check pcscd is not active
+    if systemctl is-active --quiet pcscd.socket 2>/dev/null; then
+        log_warn "  pcscd.socket is still active"
+        (( issues++ ))
+    fi
+
+    if [[ $issues -eq 0 ]]; then
+        log_success "Uninstall verification passed."
+    else
+        log_warn "$issues issue(s) found — some components may still be configured."
+        log_warn "Review log for details: $_CAC_LOG_FILE"
     fi
 }
 


### PR DESCRIPTION
New files:
- cac_setup.py / cac_uninstall.py — user-facing Python entry points; detect distro, validate sudo context, delegate to orchestrator
- bash/install.sh — 8-phase Bash execution unit (preflight, packages, opensc-conf, service, certs, import, pkcs11, verify); sources all lib/*.sh
- bash/uninstall.sh — mirrors install.sh with uninstall-phase equivalents

New uninstall functions added to existing lib files:
- lib/detect.sh: _state_read_list (reads JSON array from $STATE_FILE via python3), remove_state_and_logs (Horizon symlinks, logs, state dir)
- lib/import.sh: remove_all_certs (certutil -D per nickname from state)
- lib/pkcs11.sh: unregister_pkcs11_all (modutil -delete per db from state)
- lib/packages.sh: remove_smart_card_packages (pacman -Rs smart-card subset)
- lib/verify.sh: run_uninstall_verification (post-uninstall NSS/pcscd check)

All uninstall functions are idempotent and read state from $STATE_FILE. Entry point files set to chmod 750. Updates README.md checklist.