### PR TITLE
Add user documentation — expand README.md and unignore KNOWN_ISSUES.m…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,6 @@ CLAUDE.md
 # Root-level PLAN.md — authoritative copy lives in docs/PLAN.md
 PLAN.md
 
-# Local-only working files
-KNOWN_ISSUES.md
-
 # Upstream reference fork (local only — not part of this project's tracked code)
 linux_cac/
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,106 @@
 # CAC for Linux Distros
 
-A DoW Common Access Card (CAC / smart card) setup tool for CachyOS and other
-Arch-based Linux distributions.
+Configure your Linux system for DoW Common Access Card (CAC / smart card)
+authentication in Firefox, Chromium, Google Chrome, Microsoft Edge, and Brave.
 
-The goal is a reliable, well-tested installer that configures the full CAC
-stack — drivers, certificates, PKCS#11 module, and browser NSS databases —
-with minimal manual steps and clear diagnostics when something goes wrong.
+The tool installs all required packages, imports the DoD CA certificate bundle
+into every browser's NSS database, and registers the OpenSC PKCS#11 module —
+all in a single command, with full rollback on failure.
+
+---
+
+## Prerequisites
+
+- CachyOS, Arch Linux, EndeavourOS, Manjaro, or another Arch-based distribution
+- `sudo` access — run via `sudo python3`, **not** `sudo su` (the tool needs
+  `SUDO_USER` to write files as the correct owner)
+- All browsers closed before running
+- An active internet connection (downloads the DoD certificate bundle during
+  setup)
+- A CAC reader connected via USB
+
+---
+
+## Installation
+
+```bash
+git clone https://github.com/jeremy-g-davenport/cac_for_linux_distros.git
+cd cac_for_linux_distros
+sudo python3 cac_setup.py
+```
+
+The installer will:
+1. Install required packages (`pcsclite`, `ccid`, `opensc`, `nss`, `pcsc-tools`)
+2. Configure `/etc/opensc/opensc.conf` to force the CAC card driver
+3. Enable and start `pcscd.socket`
+4. Download and import the DoD CA certificate bundle into all browser NSS databases
+5. Register the OpenSC PKCS#11 module with every detected browser profile
+6. Run post-install verification
+
+Progress is printed to the terminal. The full log is written to
+`/var/log/cac_for_linux_distros_YYYYMMDD_HHMMSS.log`.
+
+---
+
+## Post-Install Verification
+
+After rebooting:
+
+```bash
+opensc-tool --list-readers   # Confirm the card reader is detected
+```
+
+Then open a browser and navigate to a CAC-protected site (e.g., `https://my.af.mil`).
+You should be prompted to select your CAC certificate and enter your PIN.
+
+---
+
+## Uninstallation
+
+```bash
+sudo python3 cac_uninstall.py
+```
+
+Reverses all changes made by `cac_setup.py` — certificates removed,
+PKCS#11 module unregistered, `pcscd` stopped and disabled (if it was not
+active before setup), packages optionally removed. The system is returned to
+its pre-CAC state, ready for a fresh install test.
+
+All browsers must be closed before running.
+
+---
+
+## Troubleshooting
+
+| Symptom | Resolution |
+|---|---|
+| Card reader not detected | Reboot, then run `opensc-tool --list-readers`. If still missing, see Issue #P1 in `KNOWN_ISSUES.md`. |
+| `pcscd` not running | `sudo systemctl start pcscd.socket` |
+| No PIN prompt in browser | Reboot first. If still missing, check `modutil -list -dbdir sql:~/.pki/nssdb` for "CAC Module". |
+| PIN prompt in Chrome but not Firefox | Firefox profile may not have been discovered. Run `modutil -list -dbdir sql:~/.config/mozilla/firefox/<profile>/` — see Issue #P5 in `KNOWN_ISSUES.md`. |
+| Setup fails with "no readers found" in a VM | USB passthrough may be claimed by another VM — see Issue #P4 in `KNOWN_ISSUES.md`. |
+| Certificate dialog does not appear after reboot | Check the install log at `/var/log/cac_for_linux_distros_*.log` for `[ERROR]` entries. |
+
+See `KNOWN_ISSUES.md` for a full list of documented issues and resolutions.
+
+---
+
+## Differences from Upstream linux\_cac
+
+This tool uses the same underlying mechanism as
+[`linux_cac`](https://github.com/jdjaxon/linux_cac) but makes several
+corrections:
+
+| Issue | linux\_cac behavior | This tool |
+|---|---|---|
+| `pcscd` not active until reboot | `systemctl enable` only | `enable` + `start` both called |
+| Firefox profiles not found on CachyOS | Relies on `pkcs11-register` (hardcodes `~/.mozilla/firefox`) | Uses `modutil` directly against all discovered profile paths |
+| NSS files owned by root | `certutil`/`modutil` run as root | All NSS operations run as `$REAL_USER` via `sudo -H -u` |
+| CAC card not recognised by OpenSC | No `opensc.conf` change | Forces `card_drivers = cac` in `/etc/opensc/opensc.conf` |
+| Partial uninstall risk | No uninstall script | Full uninstall with rollback via `action_log.json` |
+
+See the Assessment section of [`docs/PLAN.md`](docs/PLAN.md) for a detailed
+comparison.
 
 ---
 
@@ -37,7 +132,7 @@ controls, security policies, or acceptable use rules.
 
 ## Project Plan
 
-### Phase 1 — CLI Backend *(in development)*
+### Phase 1 — CLI Backend *(complete)*
 
 A three-layer architecture: Python orchestration (`orchestrator/`), distro
 abstraction (`distros/`), and Bash execution units (`lib/*.sh`, `bash/*.sh`).
@@ -61,7 +156,7 @@ abstraction (`distros/`), and Bash execution units (`lib/*.sh`, `bash/*.sh`).
       `bash/install.sh`, `bash/uninstall.sh`
 - [x] Testing suite — BATS unit tests with mocked system commands; Python
       `unittest` for the orchestration layer
-- [ ] User documentation — `README.md`, `KNOWN_ISSUES.md`
+- [x] User documentation — `README.md`, `KNOWN_ISSUES.md`
 
 ### Phase 2 — PyQt6 GUI Application *(planned — placeholder)*
 
@@ -99,7 +194,7 @@ installation, troubleshooting, certificate management, snapshots, and more.
 
 | Distribution family | Examples | Status |
 |---|---|---|
-| Arch-based | CachyOS, Arch Linux, EndeavourOS, Manjaro | **In Development** |
+| Arch-based | CachyOS, Arch Linux, EndeavourOS, Manjaro | **Supported** |
 
 ### Planned Distribution Support
 
@@ -116,8 +211,8 @@ installation, troubleshooting, certificate management, snapshots, and more.
 
 | Architecture | Status | Notes |
 |---|---|---|
-| `x86_64` | **In Development** | Primary target |
-| `aarch64` | **In Development** | ARM64: Raspberry Pi 4/5, Asahi Linux, ARM thin clients |
+| `x86_64` | **Supported** | Primary target |
+| `aarch64` | **Supported** | ARM64: Raspberry Pi 4/5, Asahi Linux, ARM thin clients |
 | `riscv64` | Future consideration | Negligible deployment footprint today |
 
 ---
@@ -138,4 +233,3 @@ branch name table is in [`docs/PLAN.md`](docs/PLAN.md).
 
 MIT — see [LICENSE](LICENSE) for full text.
 Copyright (c) 2026 Jeremy G. Davenport
-


### PR DESCRIPTION
…d (Step 12)

README.md:
- Add Prerequisites, Installation, Post-Install Verification, Uninstallation, Troubleshooting, and Differences from upstream linux_cac sections
- Move user-facing sections before Why/Project Plan so users find them first
- Add quick-reference troubleshooting table covering the most common symptoms
- Mark Phase 1 as complete (all items [x]); update Arch status to Supported
- Keep Why I'm Building This and Project Plan sections intact

.gitignore:
- Remove KNOWN_ISSUES.md from ignore list (file was already tracked since commit d650d87; the ignore entry was a no-op)