### PR TITLE
fix(tests): isolate PATH in detect_aur_helper BATS tests

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -196,4 +196,47 @@ failing immediately.
 
 ---
 
+## Issue #1: `source .venv/bin/activate` fails in Fish shell
+**Date found:** 2026-02-23
+**Step/Function:** VM setup / developer workflow (not install code)
+**Symptom:** Running `source .venv/bin/activate` in Fish (Konsole, KDE, CachyOS default)
+produces: *"case" builtin not inside of switch block* at line 40 of the activate script.
+**Root cause:** `.venv/bin/activate` is a Bash script. Fish cannot source it.
+Python venvs ship a Fish-specific `activate.fish`, but relying on per-shell
+scripts requires knowing the user's shell in advance.
+**Fix applied:** `tests/CachyOS_dev_VM_testing.md` updated to call venv executables
+directly by path (`.venv/bin/pip`, `.venv/bin/python`) throughout, eliminating
+any need to source an activation script. Works in any shell.
+**Verified fixed by:** GitHub issue #21 — confirmed on fresh CachyOS VM in Fish.
+
+---
+
+## Issue #2: `detect_aur_helper` BATS tests fail when `paru` is installed on the host
+**Date found:** 2026-02-24
+**Step/Function:** `tests/test_aur.bats` — `detect_aur_helper falls back to yay when paru is absent`
+  and `detect_aur_helper sets _AUR_HELPER to empty when no AUR helper found`
+**Symptom:** Two tests that should hide `paru` from `PATH` continued to find it
+  and set `_AUR_HELPER="paru"`, causing assertion failures.
+  First observed on a CachyOS development VM (Oracle VirtualBox) where `paru`
+  is installed as part of the default CachyOS package set.
+**Root cause:** The fallback test filtered `PATH` entries using
+  `grep -v paru`, which removes only directories whose *name* contains the
+  string "paru".  On CachyOS, `paru` is installed in `/usr/bin` — a directory
+  whose name does not contain "paru" — so `/usr/bin` survived the filter and
+  `command -v paru` still resolved to the real binary.
+  The "no helper" test relied on the inherited mock `PATH` from `_use_mocks()`
+  not containing `paru` or `yay`, which is true in a clean container but not
+  on a developer machine where those helpers are installed system-wide.
+**Fix applied:** `tests/test_aur.bats` — replaced the fragile `grep`-based
+  PATH filter with a fully self-contained minimal PATH for each affected test:
+  - Fallback test: `PATH="$yay_dir"` (only `yay` present; no system dirs).
+  - No-helper test: `PATH="$empty_dir"` (empty temp dir; nothing resolvable).
+  Since `detect_aur_helper` only calls `command -v paru` / `command -v yay`
+  and sourced Bash functions (`log_info`, `log_warn`), no other PATH entries
+  are needed.
+**Verified fixed by:** Issue #23 — confirmed on CachyOS VM (Oracle VirtualBox)
+  via `bats tests/test_aur.bats`; all 5 tests pass.
+
+---
+
 *Add numbered runtime issues below as testing begins.*

--- a/tests/test_aur.bats
+++ b/tests/test_aur.bats
@@ -29,15 +29,20 @@ teardown() {
     mkdir -p "$yay_dir"
     printf '#!/bin/bash\nexit 0\n' > "$yay_dir/yay"
     chmod +x "$yay_dir/yay"
-    # paru is not in PATH; only yay is
-    PATH="$yay_dir:$(echo "$PATH" | tr ':' '\n' | grep -v paru | tr '\n' ':' | sed 's/:$//')" \
-        detect_aur_helper
+    # Use a fully self-contained PATH with only yay_dir.
+    # grep -v paru only removes entries whose *directory name* contains "paru";
+    # on CachyOS, paru lives in /usr/bin, so the filter left /usr/bin in PATH
+    # and command -v paru still resolved.  A minimal PATH avoids the fragility.
+    PATH="$yay_dir" detect_aur_helper
     [[ "$_AUR_HELPER" == "yay" ]]
 }
 
 @test "detect_aur_helper sets _AUR_HELPER to empty when no AUR helper found" {
-    # PATH has mocks/ but no paru or yay executables
-    detect_aur_helper
+    # Use a minimal PATH that contains no executables at all so neither paru
+    # nor yay can be resolved, regardless of what is installed on the host.
+    local empty_dir="$BATS_TMPDIR/empty_bin"
+    mkdir -p "$empty_dir"
+    PATH="$empty_dir" detect_aur_helper
     [[ -z "$_AUR_HELPER" ]]
 }
 


### PR DESCRIPTION
Closes #23

## Summary

- **Root cause:** `grep -v paru` only strips PATH entries whose *directory name* contains "paru". On CachyOS (tested in Oracle VirtualBox VM), `paru` lives in `/usr/bin`, so `/usr/bin` survived the filter and `command -v paru` still resolved — causing `_AUR_HELPER` to be set to `paru` in tests that expected it absent.
- **Fix:** Replace fragile PATH filtering with a fully self-contained minimal PATH in each affected test:
  - `"falls back to yay"` → `PATH="$yay_dir"` (yay stub only; no system dirs)
  - `"no helper found"` → `PATH="$empty_dir"` (empty tmpdir; nothing resolvable)
- **Shell-agnostic:** BATS always runs test bodies under bash regardless of the developer's terminal shell (Fish, Zsh, etc.); `PATH="..." shell_function` is POSIX-standard bash behaviour. `log_info`/`log_warn` use only bash builtins so a minimal PATH is safe.
- **KNOWN_ISSUES.md** updated with Issue #2 documenting the root cause, fix, and CachyOS VM context.

## Test plan

- [ ] `bats tests/test_aur.bats` — all 5 assertions pass (was 2 failures + 3 passes)
- [ ] `bats tests/*.bats` — full suite: 74 tests, 0 failures, 1 skip (the `/var/log` root-only skip is expected on a non-root host)
- [ ] Verified on CachyOS development VM (Oracle VirtualBox) where `paru` is installed system-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)