### PR TITLE
fix(orchestrator): correct PHASES list to match install.sh case table

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -239,4 +239,31 @@ any need to source an activation script. Works in any shell.
 
 ---
 
+## Issue #2: `orchestrator/setup_flow.py` PHASES list out of sync with `bash/install.sh`
+**Date found:** 2026-02-24
+**Step/Function:** `orchestrator/setup_flow.py::run_setup()` — Level 2 integration test
+**Symptom:** All three tests in `tests/integration/test_full_install.bats` failed when
+  run on a CachyOS development VM (Oracle VirtualBox) with `sudo CI_INTEGRATION=1 bats`:
+  `full install completes without errors`, `verify_pcscd_service returns active after
+  install`, and `full uninstall completes without errors` all exited non-zero.
+**Root cause:** The `PHASES` list in `orchestrator/setup_flow.py` contained `"browser"`
+  (which has no corresponding `--phase=browser` case in `bash/install.sh`) and was
+  missing `"opensc-conf"` (which is a real phase in `install.sh` responsible for writing
+  `force_card_driver = cac` to `/etc/opensc/opensc.conf`).  When the orchestrator reached
+  `--phase=browser`, `install.sh` hit the `*)` catch-all, printed `[ERROR] Unknown phase`
+  to stderr, and exited 1.  `stream_bash()` raised `CalledProcessError`, which propagated
+  uncaught through `run_setup()` and `cac_setup.py`, terminating the install with a
+  non-zero exit status.  The missing `opensc-conf` phase meant OpenSC CAC driver
+  configuration was silently skipped in the Python-orchestrated path (though it was
+  executed correctly in the `--phase=all` standalone escape hatch).
+**Fix applied:** `orchestrator/setup_flow.py` — replaced the stale 7-entry PHASES list
+  with the correct 8-entry list that mirrors the `--phase=all` sequence in `install.sh`:
+  `preflight → packages → opensc-conf → service → certs → import → pkcs11 → verify`.
+  Added an inline comment directing developers to cross-check against `--phase=all`
+  in `install.sh` whenever the phase list is modified.
+**Verified fixed by:** Issue #25 — confirmed on CachyOS VM (Oracle VirtualBox)
+  via `sudo CI_INTEGRATION=1 bats tests/integration/test_full_install.bats`.
+
+---
+
 *Add numbered runtime issues below as testing begins.*

--- a/orchestrator/setup_flow.py
+++ b/orchestrator/setup_flow.py
@@ -20,16 +20,18 @@ from .state import InstallState
 BASH_DIR = Path(__file__).parent.parent / "bash"
 INSTALL_SCRIPT = BASH_DIR / "install.sh"
 
-# 7 install phases executed in order
+# 8 install phases executed in order.
+# Each name maps directly to --phase=<name> in bash/install.sh.
+# Cross-check against the --phase=all case in install.sh whenever adding phases.
 PHASES = [
-    "preflight",   # detect distro/arch, check root, check browsers closed
-    "packages",    # pacman -Syu + install required packages
-    "service",     # enable + start pcscd.socket
-    "certs",       # download and extract DoD AllCerts.zip
-    "browser",     # discover NSS databases, ensure Firefox profile exists
-    "import",      # certutil: import all DoD CA certs into each NSS db
-    "pkcs11",      # modutil: register OpenSC PKCS11 module in each NSS db
-    "verify",      # post-install verification
+    "preflight",    # detect distro/arch, check root, check browsers closed
+    "packages",     # pacman -Syu + install required packages
+    "opensc-conf",  # write force_card_driver = cac to /etc/opensc/opensc.conf
+    "service",      # detect conflicting kernel modules; enable + start pcscd.socket
+    "certs",        # download and extract DoD AllCerts.zip
+    "import",       # discover NSS databases; certutil import all DoD CA certs
+    "pkcs11",       # modutil: register OpenSC PKCS11 module in each NSS db
+    "verify",       # cleanup staging dir; post-install verification
 ]
 
 


### PR DESCRIPTION
Closes #25

## Summary

- **Root cause 1 — unknown phase crash:** `PHASES` contained `"browser"` but `bash/install.sh` has no `--phase=browser` case. The `*)` catch-all exited 1; `stream_bash()` raised `CalledProcessError`; `cac_setup.py` exited non-zero → all three integration tests failed.
- **Root cause 2 — silent phase skip:** `"opensc-conf"` was missing from `PHASES`. This phase writes `force_card_driver = cac` to `/etc/opensc/opensc.conf` (see KNOWN_ISSUES #P3). The `--phase=all` standalone escape hatch ran it correctly, but the Python-orchestrated path silently skipped it.
- **Fix:** Replaced the stale 7-entry list with the correct 8-entry list matching the `--phase=all` sequence in `install.sh`:
  `preflight → packages → opensc-conf → service → certs → import → pkcs11 → verify`
- Added an inline comment directing developers to cross-check against `--phase=all` in `install.sh` whenever PHASES is modified.
- The fix is shell-agnostic (Python data; no terminal-shell dependency).
- `KNOWN_ISSUES.md` updated with Issue #2.

## Test plan

- [ ] `sudo CI_INTEGRATION=1 bats tests/integration/test_full_install.bats` — 3/3 tests pass on CachyOS VM (Oracle VirtualBox)
- [ ] `bats tests/*.bats` — unit suite unaffected: 74 tests, 0 failures, 1 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)