### PR TITLE
docs: record verified CachyOS environment for Phase 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,20 @@ installation, troubleshooting, certificate management, snapshots, and more.
 
 ---
 
+## Verified Environments
+
+End-to-end CAC authentication confirmed working (Firefox and Chrome, certificate
+selection dialog displayed, CAC-protected site accessible):
+
+| Distribution | Desktop | Kernel | Graphics | Result |
+|---|---|---|---|---|
+| CachyOS | KDE Plasma 6.6.1 · KDE Frameworks 6.23.0 · Qt 6.10.2 | 6.19.3-2-cachyOS (x86\_64) | Wayland | **Verified** |
+
+> **Note:** On a minimal VM installation with low RAM, installation and
+> configuration takes approximately 5 minutes end-to-end.
+
+---
+
 ## Contributing
 
 See `CONTRIBUTING.md` for the full contribution guide,

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -2236,6 +2236,16 @@ Tests use stdlib `unittest` (no pytest required for Phase 1):
 
 **Test environment:** CachyOS installation (bare metal or VM snapshot restorable to clean state).
 
+**Verified environment (Phase 1 end-to-end success):**
+
+| Field | Value |
+|---|---|
+| Distribution | CachyOS |
+| Desktop | KDE Plasma 6.6.1 · KDE Frameworks 6.23.0 · Qt 6.10.2 |
+| Kernel | 6.19.3-2-cachyOS (x86_64, 64-bit) |
+| Graphics platform | Wayland |
+| Result | CAC authentication confirmed in Firefox and Chrome — certificate selection dialog displayed, CAC-protected site accessible |
+
 1. **Snapshot** clean system before any CAC setup.
 2. Run `sudo python3 cac_setup.py`; record exit code and log path.
 3. Run `verify.sh` functions directly; confirm pcscd active, modules registered, certs present.


### PR DESCRIPTION
## Summary

- Adds a **Verified Environments** section to `README.md` with a table row confirming end-to-end CAC authentication on CachyOS (KDE Plasma 6.6.1, KDE Frameworks 6.23.0, Qt 6.10.2, kernel 6.19.3-2-cachyOS, Wayland)
- Adds a matching verified environment table to the Integration Test Outline in `docs/PLAN.md`
- Notes that installation takes approximately 5 minutes on a minimal VM with low RAM

## Test plan

- [ ] Verify `README.md` renders correctly on GitHub (table and blockquote note)
- [ ] Verify `docs/PLAN.md` renders correctly on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)