### PR TITLE
feat: add Red Hat / Fedora distro support (Phase 1)

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -496,3 +496,79 @@ any need to source an activation script. Works in any shell.
 ---
 
 *Add numbered runtime issues below as testing begins.*
+
+---
+
+## Red Hat / Fedora Family Issues (pre-documented, 2026-02-28)
+
+The following issues were identified during design of Red Hat family support and addressed in `p1/redhat-distro`. They are documented here for reference during Fedora VM testing.
+
+---
+
+### FN1 — `certutil`/`modutil` not found in preflight on fresh Fedora
+
+**Date:** 2026-02-28
+**Status:** Fixed
+**Symptom:** Preflight phase exits with `E_NODEPS` — "Required tool not found: certutil" on a fresh Fedora system without `nss-tools` pre-installed.
+**Root cause:** `detect_required_tools()` in `lib/detect.sh` originally included `certutil` and `modutil` in the fatal tool-check loop. On Arch, `nss` (which ships these binaries) tends to be pre-installed as a system dependency. On Fedora, `nss-tools` is a separate optional package.
+**Fix:** Moved `certutil` and `modutil` out of the fatal loop. They are now checked with a warning-only path: `log_warn "Tool not yet available: $tool (will be installed in packages phase)"`. The fatal check happens post-install via `verify_certutil()` in the packages phase.
+**Verification:** `tests/test_detect.bats` — "detect_required_tools succeeds even when certutil is absent from PATH"
+
+---
+
+### FN2 — PKCS11 library at `/usr/lib64/` not `/usr/lib/`
+
+**Date:** 2026-02-28
+**Status:** Fixed (by design)
+**Symptom:** OpenSC PKCS11 module not found at `/usr/lib/opensc-pkcs11.so` on Fedora; browser and `pkcs11-tool` cannot load it.
+**Root cause:** Red Hat family distributions follow the multiarch convention and place 64-bit native libraries in `/usr/lib64/`. The Arch path `/usr/lib/opensc-pkcs11.so` does not exist on Fedora.
+**Fix:** `distros/redhat/config.py` sets `PKCS11_LIB = "/usr/lib64/opensc-pkcs11.so"`, injected by Python as `PKCS11_LIB` env var.
+**Verification:** Integration test — `pkcs11-tool --list-readers` and `modutil -list -dbdir ~/.pki/nssdb` should show the module loaded.
+
+---
+
+### FN3 — `opensc.conf` path differs on Fedora
+
+**Date:** 2026-02-28
+**Status:** Fixed (by design)
+**Symptom:** OpenSC does not pick up `force_card_driver = cac` setting; CAC card uses PIV-II driver instead of CAC driver.
+**Root cause:** Fedora's `opensc` RPM compiles with the config path `/etc/opensc.conf` (flat). Arch uses `/etc/opensc/opensc.conf` (subdirectory). Writing to the wrong path has no effect.
+**Fix:** `distros/redhat/config.py` sets `OPENSC_CONF = "/etc/opensc.conf"`. Python injects this as the `OPENSC_CONF` env var. `lib/opensc_conf.sh` already has a `[[ -v OPENSC_CONF ]] || OPENSC_CONF="/etc/opensc/opensc.conf"` guard; the injected value takes precedence.
+**Verification:** After install, check `/etc/opensc.conf` contains `force_card_driver = cac` (uncommented).
+
+---
+
+### FN4 — Package name differences on Fedora
+
+**Date:** 2026-02-28
+**Status:** Fixed (by design)
+**Symptom:** `dnf install pcsclite nss` fails — package names do not exist in Fedora repositories.
+**Root cause:** Fedora RPM naming differs from Arch:
+- `pcsclite` → `pcsc-lite` (hyphen, not concatenated)
+- `nss` → `nss-tools` (`certutil`/`modutil` are in the `-tools` subpackage)
+- `pcsc-tools` → `pcsc-lite-utils` (pcsc_scan and friends)
+**Fix:** `distros/redhat/config.py::REQUIRED_PACKAGES` uses the correct Fedora package names.
+**Note:** Verify `pcsc-lite-utils` package name on target Fedora version: `dnf provides pcsc_scan`
+**Verification:** After packages phase, `rpm -q pcsc-lite ccid opensc nss-tools` all return 0.
+
+---
+
+### FN5 — No AUR helper on Fedora; AUR detection must be skipped
+
+**Date:** 2026-02-28
+**Status:** Fixed
+**Symptom:** `detect_aur_helper()` hangs or errors on Fedora; no `paru` or `yay` equivalent exists.
+**Root cause:** The packages phase unconditionally called `detect_aur_helper()`, which is an Arch-specific function.
+**Fix:** `RedHatDriver.has_aur` returns `False`. Python injects `HAS_AUR=0`. `bash/install.sh` guards the call: `if [[ "${HAS_AUR:-0}" == "1" ]]; then detect_aur_helper; fi`.
+**Verification:** Packages phase completes without AUR-related errors on Fedora.
+
+---
+
+### FN6 — SELinux enforcement may silently block pcscd access
+
+**Date:** 2026-02-28
+**Status:** Informational warning added; requires VM testing to confirm
+**Symptom:** pcscd socket activates but browsers cannot communicate with it under SELinux enforcing mode; card reader reported but authentication fails.
+**Root cause:** Fedora ships with SELinux enforcing by default. The `pcscd` daemon runs as `pcscd_t`. Browser PKCS11 loading involves domain transitions that may be denied by SELinux policy depending on whether `pcsc-lite-selinux` policy is installed.
+**Fix:** `detect_selinux()` added to `lib/detect.sh`. Called from preflight phase. Emits a warning when `getenforce` returns "Enforcing", directing users to `ausearch -m avc -ts recent` if card access fails. Modern Fedora's `pcsc-lite` RPM includes the selinux subpackage.
+**Verification:** On Fedora VM: `getenforce` shows Enforcing; after install, `pkcs11-tool --list-objects --login` succeeds without AVC denials in `ausearch -m avc -ts recent`.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -546,10 +546,10 @@ The following issues were identified during design of Red Hat family support and
 **Root cause:** Fedora RPM naming differs from Arch:
 - `pcsclite` → `pcsc-lite` (hyphen, not concatenated)
 - `nss` → `nss-tools` (`certutil`/`modutil` are in the `-tools` subpackage)
-- `pcsc-tools` → `pcsc-lite-utils` (pcsc_scan and friends)
+- `pcsc-tools` → `pcsc-tools` (same name; verified on Fedora 43 via `dnf provides pcsc_scan`)
 **Fix:** `distros/redhat/config.py::REQUIRED_PACKAGES` uses the correct Fedora package names.
-**Note:** Verify `pcsc-lite-utils` package name on target Fedora version: `dnf provides pcsc_scan`
-**Verification:** After packages phase, `rpm -q pcsc-lite ccid opensc nss-tools` all return 0.
+**Verified:** Fedora 43 — `dnf provides pcsc_scan` returns `pcsc-tools-1.7.0-7.fc43.x86_64`.
+**Verification:** After packages phase, `rpm -q pcsc-lite ccid opensc nss-tools pcsc-tools` all return 0.
 
 ---
 

--- a/bash/install.sh
+++ b/bash/install.sh
@@ -33,12 +33,17 @@ case "$PHASE" in
         detect_root
         detect_real_user
         detect_required_tools
+        detect_selinux
         check_browsers_closed
         ;;
 
     --phase=packages)
         log_section "Phase 2: Package Installation"
-        detect_aur_helper
+        if [[ "${HAS_AUR:-0}" == "1" ]]; then
+            detect_aur_helper
+        else
+            log_info "AUR not available on this distro — skipping AUR helper detection."
+        fi
         install_official_packages
         verify_certutil
         detect_post_install_tools
@@ -99,8 +104,11 @@ case "$PHASE" in
         detect_root
         detect_real_user
         detect_required_tools
+        detect_selinux
         check_browsers_closed
-        detect_aur_helper
+        if [[ "${HAS_AUR:-0}" == "1" ]]; then
+            detect_aur_helper
+        fi
         install_official_packages
         verify_certutil
         detect_post_install_tools

--- a/distros/arch/config.py
+++ b/distros/arch/config.py
@@ -7,6 +7,7 @@ Valid for both x86_64 and aarch64 on Arch-based distributions.
 
 PKCS11_LIB = "/usr/lib/opensc-pkcs11.so"
 PCSCD_UNIT = "pcscd.socket"
+OPENSC_CONF = "/etc/opensc/opensc.conf"
 
 # Full package list required for CAC authentication
 REQUIRED_PACKAGES = [

--- a/distros/base.py
+++ b/distros/base.py
@@ -55,6 +55,16 @@ class DistroDriver(ABC):
     def firefox_profile_roots(self) -> list[str]:
         """Candidate paths relative to $HOME, in preference order."""
 
+    @property
+    @abstractmethod
+    def opensc_conf_path(self) -> str:
+        """Absolute path to opensc.conf, e.g. '/etc/opensc/opensc.conf'."""
+
+    @property
+    @abstractmethod
+    def has_aur(self) -> bool:
+        """True if this distro uses the Arch User Repository."""
+
     @abstractmethod
     def install_packages(self, packages: list[str]) -> list[str]:
         """Return shell command tokens to install the given packages."""

--- a/distros/debian/driver.py
+++ b/distros/debian/driver.py
@@ -41,6 +41,14 @@ class DebianDriver(DistroDriver):
     def firefox_profile_roots(self) -> list[str]:
         raise NotImplementedError
 
+    @property
+    def opensc_conf_path(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def has_aur(self) -> bool:
+        raise NotImplementedError
+
     def install_packages(self, packages: list[str]) -> list[str]:
         raise NotImplementedError
 

--- a/distros/detect.py
+++ b/distros/detect.py
@@ -15,6 +15,7 @@ OS_RELEASE_PATH = Path("/etc/os-release")
 
 _ARCH_IDS = {"cachyos", "arch", "manjaro", "endeavouros", "garuda", "artix"}
 _DEBIAN_IDS = {"ubuntu", "debian", "linuxmint", "pop", "elementary", "kali", "raspbian"}
+_REDHAT_IDS = {"fedora", "rhel", "centos", "rocky", "almalinux"}
 
 
 def detect_distro() -> tuple[DistroInfo, DistroDriver]:
@@ -37,6 +38,10 @@ def detect_distro() -> tuple[DistroInfo, DistroDriver]:
     if distro_id in _DEBIAN_IDS or "debian" in id_like or "ubuntu" in id_like:
         from .debian.driver import DebianDriver
         return info, DebianDriver(info)
+
+    if distro_id in _REDHAT_IDS or "fedora" in id_like or "rhel" in id_like:
+        from .redhat.driver import RedHatDriver
+        return info, RedHatDriver(info)
 
     raise RuntimeError(
         f"Unsupported distribution: {info.pretty_name or distro_id!r}. "

--- a/distros/redhat/config.py
+++ b/distros/redhat/config.py
@@ -1,0 +1,44 @@
+"""
+config.py — Red Hat family (Fedora, RHEL, CentOS Stream, Rocky, AlmaLinux) constants.
+
+PKCS11_LIB uses lib64 — Red Hat multiarch convention on x86_64 and aarch64.
+opensc.conf lives at the flat path /etc/opensc.conf on Fedora/RHEL; the opensc
+RPM does not use an /etc/opensc/ subdirectory as Arch does.
+"""
+
+PKCS11_LIB = "/usr/lib64/opensc-pkcs11.so"
+PCSCD_UNIT = "pcscd.socket"
+
+# /etc/opensc.conf — flat path used by Fedora/RHEL opensc RPM.
+# Arch uses /etc/opensc/opensc.conf (subdirectory).
+OPENSC_CONF = "/etc/opensc.conf"
+
+# Full package list required for CAC authentication on Fedora/RHEL.
+# Key differences from Arch:
+#   pcsclite    → pcsc-lite        (RPM naming uses a hyphen)
+#   nss         → nss-tools        (certutil/modutil are in the -tools subpackage)
+#   pcsc-tools  → pcsc-lite-utils  (pcsc_scan lives here on Fedora)
+# Verify pcsc-lite-utils name on target: dnf provides pcsc_scan
+REQUIRED_PACKAGES = [
+    "pcsc-lite",
+    "ccid",
+    "opensc",
+    "nss-tools",
+    "pcsc-lite-utils",
+    "unzip",
+    "wget",
+]
+
+# Subset offered for removal during uninstall (excludes unzip/wget/nss-tools)
+SMART_CARD_PACKAGES = [
+    "pcsc-lite",
+    "ccid",
+    "opensc",
+    "pcsc-lite-utils",
+]
+
+# Firefox profile root candidates, relative to $HOME.
+# Fedora uses the standard upstream path — no CachyOS variant.
+FIREFOX_PROFILE_ROOTS = [
+    ".mozilla/firefox",
+]

--- a/distros/redhat/config.py
+++ b/distros/redhat/config.py
@@ -15,16 +15,15 @@ OPENSC_CONF = "/etc/opensc.conf"
 
 # Full package list required for CAC authentication on Fedora/RHEL.
 # Key differences from Arch:
-#   pcsclite    → pcsc-lite        (RPM naming uses a hyphen)
-#   nss         → nss-tools        (certutil/modutil are in the -tools subpackage)
-#   pcsc-tools  → pcsc-lite-utils  (pcsc_scan lives here on Fedora)
-# Verify pcsc-lite-utils name on target: dnf provides pcsc_scan
+#   pcsclite    → pcsc-lite    (RPM naming uses a hyphen)
+#   nss         → nss-tools    (certutil/modutil are in the -tools subpackage)
+#   pcsc-tools  → pcsc-tools   (same name on Fedora; verified on Fedora 43 with dnf provides pcsc_scan)
 REQUIRED_PACKAGES = [
     "pcsc-lite",
     "ccid",
     "opensc",
     "nss-tools",
-    "pcsc-lite-utils",
+    "pcsc-tools",
     "unzip",
     "wget",
 ]
@@ -34,7 +33,7 @@ SMART_CARD_PACKAGES = [
     "pcsc-lite",
     "ccid",
     "opensc",
-    "pcsc-lite-utils",
+    "pcsc-tools",
 ]
 
 # Firefox profile root candidates, relative to $HOME.

--- a/distros/redhat/driver.py
+++ b/distros/redhat/driver.py
@@ -1,7 +1,7 @@
 """
-driver.py — ArchDriver: DistroDriver implementation for Arch-based distros.
+driver.py — RedHatDriver: DistroDriver implementation for Red Hat family distros.
 
-Covers CachyOS, Arch Linux, Manjaro, EndeavourOS, Garuda, and Artix.
+Covers Fedora, RHEL, CentOS Stream, Rocky Linux, and AlmaLinux.
 All constants sourced from config.py; no magic strings inline.
 """
 from __future__ import annotations
@@ -10,13 +10,13 @@ from ..base import DistroDriver, DistroInfo
 from . import config
 
 
-class ArchDriver(DistroDriver):
+class RedHatDriver(DistroDriver):
     def __init__(self, info: DistroInfo) -> None:
         self.distro_info = info
 
     @property
     def package_manager(self) -> str:
-        return "pacman"
+        return "dnf"
 
     @property
     def required_packages(self) -> list[str]:
@@ -44,14 +44,14 @@ class ArchDriver(DistroDriver):
 
     @property
     def has_aur(self) -> bool:
-        return True
+        return False
 
     def install_packages(self, packages: list[str]) -> list[str]:
-        return ["pacman", "-S", "--needed", "--noconfirm", *packages]
+        return ["dnf", "install", "-y", *packages]
 
     def remove_packages(self, packages: list[str]) -> list[str]:
-        return ["pacman", "-Rns", "--noconfirm", *packages]
+        return ["dnf", "remove", "-y", *packages]
 
     def sync_package_db(self) -> list[str]:
-        # Always full sync + upgrade — never -Sy alone (partial upgrade breaks rolling release)
-        return ["pacman", "-Syu", "--noconfirm"]
+        # dnf upgrade refreshes metadata and upgrades packages in one step.
+        return ["dnf", "upgrade", "-y"]

--- a/distros/redhat/driver.py
+++ b/distros/redhat/driver.py
@@ -53,5 +53,8 @@ class RedHatDriver(DistroDriver):
         return ["dnf", "remove", "-y", *packages]
 
     def sync_package_db(self) -> list[str]:
-        # dnf upgrade refreshes metadata and upgrades packages in one step.
-        return ["dnf", "upgrade", "-y"]
+        # dnf makecache refreshes package metadata without upgrading the system.
+        # Unlike Arch (rolling release), Fedora/RHEL do not require a full system
+        # upgrade before installing packages — doing so would cause unexpected
+        # multi-hundred-MB downloads during CAC setup.
+        return ["dnf", "makecache"]

--- a/distros/redhat/driver.py
+++ b/distros/redhat/driver.py
@@ -53,8 +53,8 @@ class RedHatDriver(DistroDriver):
         return ["dnf", "remove", "-y", *packages]
 
     def sync_package_db(self) -> list[str]:
-        # dnf makecache refreshes package metadata without upgrading the system.
-        # Unlike Arch (rolling release), Fedora/RHEL do not require a full system
-        # upgrade before installing packages — doing so would cause unexpected
-        # multi-hundred-MB downloads during CAC setup.
-        return ["dnf", "makecache"]
+        # No-op: assume the user has already updated the system with 'dnf upgrade'
+        # before running this tool. Unlike Arch (rolling release), Fedora/RHEL do not
+        # require a forced system sync before package install, and running dnf upgrade
+        # during CAC setup causes unexpected multi-hundred-MB downloads.
+        return ["true"]

--- a/lib/detect.sh
+++ b/lib/detect.sh
@@ -2,8 +2,8 @@
 # lib/detect.sh — Environment validation for cac_for_linux_distros
 #
 # Provides: validate_env, detect_root, detect_real_user, detect_required_tools,
-#           detect_post_install_tools, detect_conflicting_modules, detect_to_json,
-#           _state_read_list, remove_state_and_logs
+#           detect_selinux, detect_post_install_tools, detect_conflicting_modules,
+#           detect_to_json, _state_read_list, remove_state_and_logs
 #
 # OS/arch detection is handled by Python (distros/detect.py). All distro-specific
 # values (PKCS11_LIB, PCSCD_UNIT, REAL_USER, REAL_HOME, STATE_FILE) arrive as
@@ -58,14 +58,39 @@ detect_real_user() {
 
 detect_required_tools() {
     # Pre-install check: tools that must exist before packages are installed.
+    # certutil and modutil are intentionally NOT in the fatal list — they are
+    # provided by nss/nss-tools which is installed in the packages phase.
+    # They are verified post-install by verify_certutil() in packages.sh.
     local tool
-    for tool in systemctl certutil modutil getent id cut grep find date sha256sum lsmod modprobe; do
+    for tool in systemctl getent id cut grep find date sha256sum lsmod modprobe; do
         if ! command -v "$tool" > /dev/null 2>&1; then
             log_error "Required tool not found: $tool"
             exit "$E_NODEPS"
         fi
     done
+    # certutil/modutil: warn if absent — they arrive via the packages phase.
+    for tool in certutil modutil; do
+        if ! command -v "$tool" > /dev/null 2>&1; then
+            log_warn "Tool not yet available: $tool (will be installed in packages phase)"
+        fi
+    done
     log_success "All prerequisite tools found."
+}
+
+detect_selinux() {
+    # Informational only — SELinux enforcing mode does not prevent CAC setup,
+    # but unexpected AVC denials can silently block pcscd socket access.
+    # This function is a no-op on Arch and other non-SELinux systems where
+    # getenforce is absent.
+    command -v getenforce > /dev/null 2>&1 || return 0
+    local mode
+    mode="$(getenforce 2>/dev/null || echo 'Unknown')"
+    if [[ "$mode" == "Enforcing" ]]; then
+        log_warn "SELinux is Enforcing. pcscd policies should be covered by pcsc-lite-selinux."
+        log_warn "If card access fails after install, run: sudo ausearch -m avc -ts recent"
+    else
+        log_info "SELinux mode: $mode"
+    fi
 }
 
 detect_post_install_tools() {

--- a/lib/packages.sh
+++ b/lib/packages.sh
@@ -4,28 +4,85 @@
 # Provides: install_official_packages, is_package_installed, verify_certutil,
 #           emit_packages_state, remove_smart_card_packages
 #
-# MAINTENANCE NOTE: REQUIRED_PACKAGES is also defined in distros/arch/config.py.
-# Both lists must be kept in sync. The Bash list is the executable authority;
+# MAINTENANCE NOTE: REQUIRED_PACKAGES is also defined in distros/*/config.py.
+# Both lists must be kept in sync per distro. The Bash list (populated from
+# REQUIRED_PACKAGES_ENV injected by Python) is the executable authority;
 # the Python list is used for pre-flight validation before Bash runs.
+#
+# Package management is driven by env vars injected by the Python orchestrator:
+#   PKG_QUERY_CMD      — command to check if a package is installed (e.g. "pacman -Qi")
+#   PKG_SYNC_CMD       — full sync+upgrade command (e.g. "pacman -Syu --noconfirm")
+#   PKG_INSTALL_PREFIX — install command prefix, packages appended (e.g. "dnf install -y")
+#   PKG_REMOVE_PREFIX  — remove command prefix, packages appended (e.g. "dnf remove -y")
+#   REQUIRED_PACKAGES_ENV   — space-separated package list (overrides Arch defaults)
+#   SMART_CARD_PACKAGES_ENV — space-separated smart-card-only list (overrides Arch defaults)
+#
+# All env vars fall back to Arch/pacman defaults when unset, preserving
+# standalone developer mode (bash/install.sh --phase=packages without Python).
 #
 # No set -euo pipefail — inherited from bash/install.sh or bash/uninstall.sh.
 
-# Guard with [[ -v ]] for safe BATS re-sourcing
-[[ -v REQUIRED_PACKAGES ]] || readonly REQUIRED_PACKAGES=(pcsclite ccid opensc nss pcsc-tools unzip wget)
+# Populate REQUIRED_PACKAGES array from injected env var or Arch defaults.
+# [[ -v ]] guard prevents re-declaration when BATS re-sources this file.
+if [[ -v REQUIRED_PACKAGES ]]; then
+    : # already set (BATS re-source guard)
+elif [[ -n "${REQUIRED_PACKAGES_ENV:-}" ]]; then
+    # shellcheck disable=SC2206
+    read -ra REQUIRED_PACKAGES <<< "$REQUIRED_PACKAGES_ENV"
+else
+    REQUIRED_PACKAGES=(pcsclite ccid opensc nss pcsc-tools unzip wget)
+fi
+
+# Populate SMART_CARD_PACKAGES_LIST from injected env var or Arch defaults.
+# Named SMART_CARD_PACKAGES_LIST to avoid collision with SMART_CARD_PACKAGES_ENV.
+if [[ -v SMART_CARD_PACKAGES_LIST ]]; then
+    : # already set (BATS re-source guard)
+elif [[ -n "${SMART_CARD_PACKAGES_ENV:-}" ]]; then
+    # shellcheck disable=SC2206
+    read -ra SMART_CARD_PACKAGES_LIST <<< "$SMART_CARD_PACKAGES_ENV"
+else
+    SMART_CARD_PACKAGES_LIST=(pcsclite ccid opensc pcsc-tools)
+fi
 
 is_package_installed() {
-    # Returns 0 if the package is known to pacman, non-zero otherwise.
-    pacman -Qi "$1" > /dev/null 2>&1
+    # Returns 0 if the package is installed, non-zero otherwise.
+    # Uses PKG_QUERY_CMD injected by Python (e.g. "pacman -Qi" or "rpm -q").
+    # Falls back to pacman for standalone developer use.
+    local -a q
+    # shellcheck disable=SC2206
+    read -ra q <<< "${PKG_QUERY_CMD:-pacman -Qi}"
+    "${q[@]}" "$1" > /dev/null 2>&1
+}
+
+_get_package_version() {
+    # Extract the installed version string for a package.
+    # Output format varies by package manager; returns "unknown" when unrecognised.
+    local pkg="$1"
+    case "${PKG_QUERY_CMD:-pacman -Qi}" in
+        pacman*)
+            pacman -Qi "$pkg" 2>/dev/null | awk '/^Version/{print $3; exit}'
+            ;;
+        rpm*)
+            rpm -q --qf '%{VERSION}-%{RELEASE}\n' "$pkg" 2>/dev/null | head -1
+            ;;
+        *)
+            echo "unknown"
+            ;;
+    esac
 }
 
 install_official_packages() {
     log_section "Package Installation"
 
-    # IMPORTANT: On Arch/CachyOS (rolling release), `pacman -Sy` without `-u`
-    # is a "partial upgrade" that can break installed packages by installing
-    # newer deps against older system libraries. Always `pacman -Syu` first.
+    # Sync package database and upgrade before installing.
+    # For Arch/CachyOS (rolling release): PKG_SYNC_CMD is "pacman -Syu --noconfirm".
+    # On Arch, never use -Sy alone — partial upgrade breaks system libraries.
+    # For Red Hat: PKG_SYNC_CMD is "dnf upgrade -y".
+    local -a sync_tokens
+    # shellcheck disable=SC2206
+    read -ra sync_tokens <<< "${PKG_SYNC_CMD:-pacman -Syu --noconfirm}"
     log_info "Syncing package database and upgrading system..."
-    if ! log_cmd pacman -Syu --noconfirm; then
+    if ! log_cmd "${sync_tokens[@]}"; then
         log_error "System sync/upgrade failed. Check network connectivity."
         exit "$E_NODEPS"
     fi
@@ -42,7 +99,10 @@ install_official_packages() {
 
     if [[ ${#to_install[@]} -gt 0 ]]; then
         log_info "Installing packages: ${to_install[*]}"
-        if ! log_cmd pacman -S --needed --noconfirm "${to_install[@]}"; then
+        local -a install_tokens
+        # shellcheck disable=SC2206
+        read -ra install_tokens <<< "${PKG_INSTALL_PREFIX:-pacman -S --needed --noconfirm}"
+        if ! log_cmd "${install_tokens[@]}" "${to_install[@]}"; then
             log_error "Package installation failed. See log: $_CAC_LOG_FILE"
             exit "$E_NODEPS"
         fi
@@ -55,13 +115,16 @@ install_official_packages() {
 }
 
 verify_certutil() {
-    # Confirms the nss package landed correctly.
+    # Confirms certutil and modutil are available after the packages phase.
+    # On Arch they come from 'nss'; on Fedora/RHEL from 'nss-tools'.
     if ! command -v certutil > /dev/null 2>&1; then
-        log_error "certutil not found after installing nss. Try: pacman -S nss"
+        log_error "certutil not found after installing packages."
+        log_error "The nss-tools (or nss) package may have failed to install."
         exit "$E_NODEPS"
     fi
     if ! command -v modutil > /dev/null 2>&1; then
-        log_error "modutil not found after installing nss. Try: pacman -S nss"
+        log_error "modutil not found after installing packages."
+        log_error "The nss-tools (or nss) package may have failed to install."
         exit "$E_NODEPS"
     fi
     log_success "certutil and modutil confirmed: $(command -v certutil)"
@@ -74,7 +137,7 @@ emit_packages_state() {
     local pkg ver
     for pkg in "${REQUIRED_PACKAGES[@]}"; do
         if is_package_installed "$pkg"; then
-            ver="$(pacman -Qi "$pkg" 2>/dev/null | awk '/^Version/{print $3; exit}')"
+            ver="$(_get_package_version "$pkg")"
             installed+=("${pkg}=${ver}")
         fi
     done
@@ -85,20 +148,18 @@ emit_packages_state() {
 remove_smart_card_packages() {
     # Remove only smart-card-specific packages that were installed by this tool.
     # Reads packages_installed from $STATE_FILE via _state_read_list (lib/detect.sh).
-    # Intersects with SMART_CARD_ONLY to avoid removing general utilities (wget, unzip).
-    # Uses `pacman -Rs` to also remove orphaned dependencies.
+    # Intersects with SMART_CARD_PACKAGES_LIST to avoid removing general utilities
+    # (wget, unzip, nss/nss-tools).
     log_section "Package Removal"
 
-    # Packages this tool installed
+    # Packages this tool installed (strip version suffixes: pkg=version → pkg)
     local installed_by_tool=()
     mapfile -t installed_by_tool < <(_state_read_list "packages_installed" \
-        | sed 's/=.*//')   # strip version suffixes (pkg=version → pkg)
+        | sed 's/=.*//')
 
-    # Packages safe to remove (smart-card-specific only; not wget/unzip/nss)
-    local smart_card_only=(pcsclite ccid opensc pcsc-tools)
     local to_remove=()
     local pkg
-    for pkg in "${smart_card_only[@]}"; do
+    for pkg in "${SMART_CARD_PACKAGES_LIST[@]}"; do
         if printf '%s\n' "${installed_by_tool[@]}" | grep -qx "$pkg"; then
             if is_package_installed "$pkg"; then
                 to_remove+=("$pkg")
@@ -112,10 +173,13 @@ remove_smart_card_packages() {
     fi
 
     log_info "Removing packages: ${to_remove[*]}"
+    local -a remove_tokens
+    # shellcheck disable=SC2206
+    read -ra remove_tokens <<< "${PKG_REMOVE_PREFIX:-pacman -Rns --noconfirm}"
     local s=0
-    pacman -Rs --noconfirm "${to_remove[@]}" >> "$_CAC_LOG_FILE" 2>&1 || s=$?
+    "${remove_tokens[@]}" "${to_remove[@]}" >> "$_CAC_LOG_FILE" 2>&1 || s=$?
     if [[ $s -ne 0 ]]; then
-        log_warn "pacman -Rs returned $s — packages may have already been removed (non-fatal)"
+        log_warn "Package removal returned $s — packages may have already been removed (non-fatal)"
     else
         log_success "Packages removed: ${to_remove[*]}"
         echo "ACTION:packages_removed|${to_remove[*]}"

--- a/lib/pkcs11.sh
+++ b/lib/pkcs11.sh
@@ -89,7 +89,7 @@ register_pkcs11_all() {
 
     if [[ ! -f "$OPENSC_PKCS11_LIB" ]]; then
         log_error "OpenSC PKCS11 library not found: $OPENSC_PKCS11_LIB"
-        log_error "Ensure opensc is installed: pacman -S opensc"
+        log_error "Ensure opensc is installed (e.g. pacman -S opensc / dnf install -y opensc)."
         exit 1
     fi
 

--- a/orchestrator/setup_flow.py
+++ b/orchestrator/setup_flow.py
@@ -170,6 +170,15 @@ def _parse_action_detail(action_type: str, extra: list[str]) -> dict:
     return {"raw": extra}
 
 
+# Map from package_manager name to the shell command used to query a single package.
+# Injected as PKG_QUERY_CMD into Bash; lib/packages.sh uses it in is_package_installed().
+_PM_QUERY: dict[str, str] = {
+    "pacman": "pacman -Qi",
+    "dnf":    "rpm -q",
+    "apt":    "dpkg -s",
+}
+
+
 def _build_env(driver, sudo_user: str, state: InstallState) -> dict:
     """Build the environment dict injected into every Bash subprocess."""
     import os
@@ -186,4 +195,17 @@ def _build_env(driver, sudo_user: str, state: InstallState) -> dict:
         env["REAL_HOME"] = pwd.getpwnam(sudo_user).pw_dir
     except (KeyError, ImportError):
         env["REAL_HOME"] = f"/home/{sudo_user}"
+
+    # Distro-specific package management env vars consumed by lib/packages.sh.
+    # install_packages([]) / remove_packages([]) return just the command prefix
+    # (empty packages list → no trailing args appended).
+    env["OPENSC_CONF"]             = driver.opensc_conf_path
+    env["HAS_AUR"]                 = "1" if driver.has_aur else "0"
+    env["PKG_QUERY_CMD"]           = _PM_QUERY.get(driver.package_manager, driver.package_manager)
+    env["PKG_SYNC_CMD"]            = " ".join(driver.sync_package_db())
+    env["PKG_INSTALL_PREFIX"]      = " ".join(driver.install_packages([]))
+    env["PKG_REMOVE_PREFIX"]       = " ".join(driver.remove_packages([]))
+    env["REQUIRED_PACKAGES_ENV"]   = " ".join(driver.required_packages)
+    env["SMART_CARD_PACKAGES_ENV"] = " ".join(driver.smart_card_packages)
+
     return env

--- a/tests/Fedora_dev_VM_testing.md
+++ b/tests/Fedora_dev_VM_testing.md
@@ -118,7 +118,7 @@ sudo .venv/bin/python cac_setup.py
 
 Watch the output for phase-by-phase progress. The phases in order are:
 1. `preflight` — root check, detect_selinux, browser check
-2. `packages` — dnf makecache (refresh metadata) + dnf install (no AUR helper prompt)
+2. `packages` — dnf install only (run `sudo dnf upgrade` manually beforehand if needed)
 3. `opensc-conf` — writes `force_card_driver = cac` to `/etc/opensc.conf`
 4. `service` — enables and starts `pcscd.socket`
 5. `certs` — downloads and extracts DoD AllCerts.zip

--- a/tests/Fedora_dev_VM_testing.md
+++ b/tests/Fedora_dev_VM_testing.md
@@ -96,7 +96,9 @@ bats tests/*.bats
 
 > **Snapshot first.** Take a VirtualBox snapshot named "pre-integration-test" before running so you can roll back cleanly.
 
-The integration test suite runs a real install + uninstall cycle. It auto-skips unless `CI_INTEGRATION=1` is set, and requires root.
+The integration test suite auto-detects the running distro (Arch or Red Hat family), runs a full install + uninstall cycle, and verifies distro-specific paths and packages. It auto-skips unless `CI_INTEGRATION=1` is set and requires root.
+
+The install and uninstall steps stream live output so you can watch `dnf` progress in real time.
 
 ```bash
 sudo CI_INTEGRATION=1 bats tests/integration/test_full_install.bats

--- a/tests/Fedora_dev_VM_testing.md
+++ b/tests/Fedora_dev_VM_testing.md
@@ -1,0 +1,263 @@
+# Testing CAC for Linux Distros — Fedora VM
+
+> **Policy:** Always test in the Fedora VM and confirm success there before running anything on your own machine.
+
+There are three levels of testing, from safest to most invasive.
+
+---
+
+## VM Prerequisites (fresh Fedora install, terminal only)
+
+Before anything else, install required tools. `bats` is available in the Fedora repos:
+
+```bash
+sudo dnf install -y git gh bats python3 python3-pip
+```
+
+Authenticate with GitHub:
+
+```bash
+gh auth login
+# Choose: GitHub.com → HTTPS → Login with a web browser
+# Follow the one-time code prompt in the browser
+```
+
+Clone the repo and check out the PR branch (before PR #36 is merged):
+
+```bash
+git clone https://github.com/jeremy-g-davenport/cac_for_linux_distros.git
+cd cac_for_linux_distros
+git checkout p1/redhat-distro
+```
+
+> After PR #36 is merged, use `main` instead: `git checkout main && git pull`
+
+Set up the Python virtual environment:
+
+```bash
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+> **Note:** Call `.venv/bin/pip` and `.venv/bin/python` directly instead of sourcing the activate script — this works in any shell.
+
+---
+
+## Step 0: Verify Package Names (Fedora-specific, do this first)
+
+Confirm the `pcsc_scan` utility package name on this Fedora version:
+
+```bash
+dnf provides pcsc_scan
+```
+
+Expected output (verified on Fedora 43):
+```
+pcsc-tools-1.7.0-7.fc43.x86_64 : Tools to be used with smart cards and PC/SC
+```
+
+The package is `pcsc-tools` — same name as on Arch. If a future Fedora version returns a different package name, update `distros/redhat/config.py::REQUIRED_PACKAGES` before proceeding.
+
+Also confirm all required package names resolve:
+
+```bash
+dnf info pcsc-lite ccid opensc nss-tools pcsc-tools unzip wget
+```
+
+All seven should resolve without "No match for argument" errors.
+
+---
+
+## Level 1: Unit Tests (safe — no system changes)
+
+These run entirely with mocks — no real packages installed, no sudo required.
+
+```bash
+# BATS unit tests (Bash layer)
+bats tests/*.bats
+
+# Python unit tests (orchestrator layer)
+.venv/bin/python -m unittest discover -s tests/test_orchestrator -v
+```
+
+**Expected results:** All BATS and Python tests pass. Key Fedora-specific tests to confirm:
+
+| Test file | What it checks |
+|---|---|
+| `test_orchestrator/test_redhat_driver.py` | RedHatDriver properties (lib64, dnf, no AUR) |
+| `test_orchestrator/test_build_env_redhat.py` | `_build_env()` injects correct Fedora env vars |
+| `test_orchestrator/test_distro_detect.py` | `ID=fedora` routes to `RedHatDriver` |
+| `tests/test_packages.bats` | Red Hat scenario: dnf upgrade + dnf install |
+| `tests/test_detect.bats` | certutil absent = warning only; detect_selinux behavior |
+
+---
+
+## Level 2: Integration Tests (requires root — snapshot first)
+
+> **Snapshot first.** Take a VirtualBox snapshot named "pre-integration-test" before running so you can roll back cleanly.
+
+The integration test suite runs a real install + uninstall cycle. It auto-skips unless `CI_INTEGRATION=1` is set, and requires root.
+
+```bash
+sudo CI_INTEGRATION=1 bats tests/integration/test_full_install.bats
+```
+
+---
+
+## Level 3: Manual End-to-End (real CAC card, real VM)
+
+> **Snapshot first.** Take a VirtualBox snapshot named "pre-e2e-test" before this step.
+
+### Install
+
+```bash
+sudo .venv/bin/python cac_setup.py
+```
+
+Watch the output for phase-by-phase progress. The phases in order are:
+1. `preflight` — root check, detect_selinux, browser check
+2. `packages` — dnf upgrade + dnf install (no AUR helper prompt)
+3. `opensc-conf` — writes `force_card_driver = cac` to `/etc/opensc.conf`
+4. `service` — enables and starts `pcscd.socket`
+5. `certs` — downloads and extracts DoD AllCerts.zip
+6. `import` — imports CA certs into NSS databases
+7. `pkcs11` — registers OpenSC PKCS11 module
+8. `verify` — cleanup and post-install verification
+
+### Verify state was written
+
+```bash
+cat /var/lib/cac_for_linux_distros/state.json
+cat /var/lib/cac_for_linux_distros/action_log.json
+```
+
+### Uninstall
+
+```bash
+sudo .venv/bin/python cac_uninstall.py
+```
+
+---
+
+## Fedora-Specific Verification Checklist
+
+Work through these after a successful install. Each item corresponds to a known issue (FN1–FN6) addressed in this release.
+
+### FN1 — certutil not fatal in preflight
+
+In the install output, preflight should **not** exit with an error about `certutil`. Instead it should print a warning like:
+
+```
+[WARN] Tool not yet available: certutil (will be installed in packages phase)
+```
+
+Then after the packages phase, certutil should be available:
+
+```bash
+which certutil
+certutil --version
+```
+
+### FN2 — PKCS11 library at lib64
+
+Confirm the correct library path was used:
+
+```bash
+ls -lh /usr/lib64/opensc-pkcs11.so
+```
+
+Confirm the module is registered in the user's NSS database:
+
+```bash
+modutil -list -dbdir ~/.pki/nssdb
+```
+
+Should list `opensc-pkcs11` pointing to `/usr/lib64/opensc-pkcs11.so`.
+
+Also test with a CAC reader plugged in:
+
+```bash
+pkcs11-tool --module /usr/lib64/opensc-pkcs11.so --list-readers
+pkcs11-tool --module /usr/lib64/opensc-pkcs11.so --list-objects --login
+```
+
+### FN3 — opensc.conf at flat path
+
+Confirm the config was written to the correct (flat) Fedora path:
+
+```bash
+grep "force_card_driver" /etc/opensc.conf
+```
+
+Expected: `force_card_driver = cac` (uncommented). The file `/etc/opensc/opensc.conf` should not exist (or should not have the setting if it does exist).
+
+### FN4 — Package names resolved correctly
+
+Confirm all packages were installed with correct RPM names:
+
+```bash
+rpm -q pcsc-lite ccid opensc nss-tools pcsc-tools unzip wget
+```
+
+All seven should return package info, not "package X is not installed".
+
+### FN5 — AUR skipped cleanly
+
+In the install output, packages phase should show:
+
+```
+AUR not available on this distro — skipping AUR helper detection.
+```
+
+No prompt for `paru`, `yay`, or any other AUR helper should appear.
+
+### FN6 — SELinux status
+
+In the preflight output, look for the SELinux status line. On a default Fedora install with SELinux enforcing:
+
+```
+[WARN] SELinux is Enforcing. pcscd policies should be covered by pcsc-lite-selinux.
+[WARN] If card access fails after install, run: sudo ausearch -m avc -ts recent
+```
+
+After the full install, check for AVC denials that would block CAC access:
+
+```bash
+sudo ausearch -m avc -ts recent 2>/dev/null | grep pcscd
+```
+
+Ideally: no output (no denials). If denials appear, `pcsc-lite-selinux` may need manual installation:
+
+```bash
+sudo dnf install -y pcsc-lite-selinux
+sudo systemctl restart pcscd.socket
+```
+
+---
+
+## Recommended VM Test Workflow
+
+```
+1. Take snapshot "pre-e2e-test"
+2. Run: sudo .venv/bin/python cac_setup.py
+3. Work through the Fedora-Specific Verification Checklist above
+4. Insert CAC card (USB passthrough) → verify browser auth works
+5. Run: sudo .venv/bin/python cac_uninstall.py
+6. Verify system is clean (state.json gone or reset; rpm -q opensc returns not installed)
+7. Restore snapshot for next test run
+```
+
+**VirtualBox USB passthrough for the CAC reader:**
+- In VirtualBox: `Settings → USB → USB 3.0 Controller` → click the `+` icon and add your CAC reader by name
+- Plug the reader in before starting the VM, or hot-attach it after boot
+
+---
+
+## What to Report
+
+If anything fails, note:
+- Which phase failed (preflight / packages / opensc-conf / service / certs / import / pkcs11 / verify)
+- The exact error line from terminal output
+- Output of `getenforce` (SELinux mode)
+- Fedora version: `cat /etc/fedora-release`
+- Whether the failure corresponds to FN1–FN6 above or is a new issue

--- a/tests/Fedora_dev_VM_testing.md
+++ b/tests/Fedora_dev_VM_testing.md
@@ -87,7 +87,7 @@ bats tests/*.bats
 | `test_orchestrator/test_redhat_driver.py` | RedHatDriver properties (lib64, dnf, no AUR) |
 | `test_orchestrator/test_build_env_redhat.py` | `_build_env()` injects correct Fedora env vars |
 | `test_orchestrator/test_distro_detect.py` | `ID=fedora` routes to `RedHatDriver` |
-| `tests/test_packages.bats` | Red Hat scenario: dnf upgrade + dnf install |
+| `tests/test_packages.bats` | Red Hat scenario: dnf makecache + dnf install |
 | `tests/test_detect.bats` | certutil absent = warning only; detect_selinux behavior |
 
 ---
@@ -118,7 +118,7 @@ sudo .venv/bin/python cac_setup.py
 
 Watch the output for phase-by-phase progress. The phases in order are:
 1. `preflight` — root check, detect_selinux, browser check
-2. `packages` — dnf upgrade + dnf install (no AUR helper prompt)
+2. `packages` — dnf makecache (refresh metadata) + dnf install (no AUR helper prompt)
 3. `opensc-conf` — writes `force_card_driver = cac` to `/etc/opensc.conf`
 4. `service` — enables and starts `pcscd.socket`
 5. `certs` — downloads and extracts DoD AllCerts.zip

--- a/tests/helpers/bats_helper.bash
+++ b/tests/helpers/bats_helper.bash
@@ -35,9 +35,12 @@ _setup_mock_logs() {
     export MOCK_WGET_LOG="$BATS_TMPDIR/mock_wget.log"
     export MOCK_UNZIP_LOG="$BATS_TMPDIR/mock_unzip.log"
     export MOCK_UDEVADM_LOG="$BATS_TMPDIR/mock_udevadm.log"
+    export MOCK_DNF_LOG="$BATS_TMPDIR/mock_dnf.log"
+    export MOCK_RPM_LOG="$BATS_TMPDIR/mock_rpm.log"
     rm -f "$MOCK_PACMAN_LOG" "$MOCK_SYSTEMCTL_LOG" "$MOCK_MODUTIL_LOG" \
           "$MOCK_CERTUTIL_LOG" "$MOCK_WGET_LOG" "$MOCK_UNZIP_LOG" \
-          "$MOCK_UDEVADM_LOG" "$_CCID_RULES_FILE"
+          "$MOCK_UDEVADM_LOG" "$MOCK_DNF_LOG" "$MOCK_RPM_LOG" \
+          "$_CCID_RULES_FILE"
 }
 
 # Source the SCRIPT_DIR-resolved lib file.

--- a/tests/helpers/set_test_env.sh
+++ b/tests/helpers/set_test_env.sh
@@ -1,14 +1,35 @@
 #!/bin/bash
-# tests/helpers/set_test_env.sh — Export required env vars with Arch defaults.
+# tests/helpers/set_test_env.sh — Export required env vars, distro-aware.
 #
 # Usage: source tests/helpers/set_test_env.sh
 #
 # Required when running bash/install.sh or bash/uninstall.sh directly
-# (without the Python orchestrator) for integration testing.
-# Python normally injects these via orchestrator/runner.py _build_env().
+# (without the Python orchestrator) for integration testing or the
+# developer standalone escape hatch.  Python normally injects these
+# via orchestrator/setup_flow.py::_build_env().
 
-export PKCS11_LIB="/usr/lib/opensc-pkcs11.so"
+_id="$(. /etc/os-release 2>/dev/null && echo "${ID:-arch}")"
+_id_like="$(. /etc/os-release 2>/dev/null && echo "${ID_LIKE:-}")"
+
+case "$_id" in
+    fedora|rhel|centos|rocky|almalinux)
+        _FAMILY="redhat" ;;
+    *)
+        case "$_id_like" in
+            *fedora*|*rhel*) _FAMILY="redhat" ;;
+            *)               _FAMILY="arch"   ;;
+        esac ;;
+esac
+
+if [[ "$_FAMILY" == "redhat" ]]; then
+    export PKCS11_LIB="/usr/lib64/opensc-pkcs11.so"
+else
+    export PKCS11_LIB="/usr/lib/opensc-pkcs11.so"
+fi
+
 export PCSCD_UNIT="pcscd.socket"
 export REAL_USER="${SUDO_USER:-$USER}"
 export REAL_HOME="${HOME}"
 export STATE_FILE="/var/lib/cac_for_linux_distros/state.json"
+
+unset _id _id_like _FAMILY

--- a/tests/integration/test_full_install.bats
+++ b/tests/integration/test_full_install.bats
@@ -1,38 +1,139 @@
 #!/usr/bin/env bats
-# tests/integration/test_full_install.bats — Full install/uninstall integration tests.
+# tests/integration/test_full_install.bats — Distro-agnostic full install/uninstall tests.
 #
-# These tests require a real CachyOS/Arch system with:
-#   - The full package set (pcsclite, ccid, opensc, nss)
-#   - Firefox or Chromium installed
-#   - sudo access
+# Supported distro families:
+#   arch    — Arch, CachyOS, EndeavourOS, Manjaro
+#   redhat  — Fedora, RHEL, CentOS Stream, Rocky, AlmaLinux
 #
-# Skipped automatically in hosted CI unless CI_INTEGRATION=1 is set.
-# A self-hosted Arch runner sets CI_INTEGRATION=1 to enable them.
+# Requirements:
+#   - Run as root (sudo)
+#   - .venv/ present at repo root with requirements installed
+#   - CI_INTEGRATION=1 set in environment
+#
+# Run:
+#   sudo CI_INTEGRATION=1 bats tests/integration/test_full_install.bats
+#
+# The install and uninstall tests run WITHOUT the 'run' wrapper so that
+# dnf/pacman progress streams live to the terminal instead of being swallowed.
+
+# ---------------------------------------------------------------------------
+# Distro detection helper
+# ---------------------------------------------------------------------------
+
+_detect_distro_family() {
+    local id id_like
+    id="$(. /etc/os-release 2>/dev/null && echo "${ID:-}")"
+    id_like="$(. /etc/os-release 2>/dev/null && echo "${ID_LIKE:-}")"
+    case "$id" in
+        arch|cachyos|endeavouros|manjaro)    echo "arch"   ; return ;;
+        fedora|rhel|centos|rocky|almalinux) echo "redhat" ; return ;;
+        ubuntu|debian|linuxmint|pop)        echo "debian" ; return ;;
+    esac
+    case "$id_like" in
+        *arch*)            echo "arch"   ; return ;;
+        *fedora*|*rhel*)   echo "redhat" ; return ;;
+        *debian*|*ubuntu*) echo "debian" ; return ;;
+    esac
+    echo "unknown"
+}
+
+# ---------------------------------------------------------------------------
+# setup — runs before every test; sets distro-specific variables
+# ---------------------------------------------------------------------------
 
 setup() {
     if [[ -z "${CI_INTEGRATION:-}" ]]; then
-        skip "integration tests require CI_INTEGRATION=1 (real Arch system)"
+        skip "integration tests require CI_INTEGRATION=1"
     fi
     if [[ $(id -u) -ne 0 ]]; then
-        skip "integration tests require root (sudo)"
+        skip "integration tests require root"
     fi
-    source "$(dirname "$BATS_TEST_FILENAME")/../../tests/helpers/set_test_env.sh"
+
+    DISTRO_FAMILY="$(_detect_distro_family)"
+
+    case "$DISTRO_FAMILY" in
+        arch)
+            INTEG_PKG_QUERY="pacman -Qi"
+            INTEG_SMART_CARD_PKGS="pcsclite ccid opensc"
+            INTEG_PKCS11_LIB="/usr/lib/opensc-pkcs11.so"
+            INTEG_OPENSC_CONF="/etc/opensc/opensc.conf"
+            ;;
+        redhat)
+            INTEG_PKG_QUERY="rpm -q"
+            INTEG_SMART_CARD_PKGS="pcsc-lite ccid opensc"
+            INTEG_PKCS11_LIB="/usr/lib64/opensc-pkcs11.so"
+            INTEG_OPENSC_CONF="/etc/opensc.conf"
+            ;;
+        *)
+            local detected_id
+            detected_id="$(. /etc/os-release 2>/dev/null && echo "${ID:-unknown}")"
+            skip "unsupported distro family: $DISTRO_FAMILY (ID=$detected_id)"
+            ;;
+    esac
 }
+
+# ---------------------------------------------------------------------------
+# Install
+# ---------------------------------------------------------------------------
 
 @test "full install completes without errors" {
-    run python3 cac_setup.py
+    # No 'run' wrapper — output streams live so dnf/pacman progress is visible.
+    .venv/bin/python cac_setup.py
+}
+
+# ---------------------------------------------------------------------------
+# Post-install verification
+# ---------------------------------------------------------------------------
+
+@test "smart card packages are installed after install" {
+    local -a query pkgs
+    read -ra query <<< "$INTEG_PKG_QUERY"
+    read -ra pkgs  <<< "$INTEG_SMART_CARD_PKGS"
+    for pkg in "${pkgs[@]}"; do
+        run "${query[@]}" "$pkg"
+        [ "$status" -eq 0 ]
+    done
+}
+
+@test "opensc.conf has force_card_driver = cac" {
+    grep -q "^force_card_driver[[:space:]]*=[[:space:]]*cac" "$INTEG_OPENSC_CONF"
+}
+
+@test "pkcs11 library exists at distro-expected path" {
+    [ -f "$INTEG_PKCS11_LIB" ]
+}
+
+@test "pcscd socket is active after install" {
+    run systemctl is-active pcscd.socket
     [ "$status" -eq 0 ]
 }
 
-@test "verify_pcscd_service returns active after install" {
-    source lib/log.sh
-    source lib/service.sh
-    log_init
-    run verify_pcscd_service
-    [ "$status" -eq 0 ]
+@test "state file written after install" {
+    [ -f "/var/lib/cac_for_linux_distros/state.json" ]
 }
+
+# ---------------------------------------------------------------------------
+# Uninstall
+# ---------------------------------------------------------------------------
 
 @test "full uninstall completes without errors" {
-    run python3 cac_uninstall.py
-    [ "$status" -eq 0 ]
+    # No 'run' wrapper — output streams live.
+    .venv/bin/python cac_uninstall.py
+}
+
+@test "pcscd socket is not active after uninstall" {
+    run systemctl is-active pcscd.socket
+    [ "$status" -ne 0 ]
+}
+
+@test "state file absent or packages cleared after uninstall" {
+    # Either the state file is gone, or packages_installed is empty.
+    if [[ -f "/var/lib/cac_for_linux_distros/state.json" ]]; then
+        run .venv/bin/python -c "
+import json, sys
+state = json.load(open('/var/lib/cac_for_linux_distros/state.json'))
+sys.exit(0 if not state.get('packages_installed') else 1)
+"
+        [ "$status" -eq 0 ]
+    fi
 }

--- a/tests/mocks/dnf
+++ b/tests/mocks/dnf
@@ -1,0 +1,14 @@
+#!/bin/bash
+# tests/mocks/dnf — Configurable stub.
+# Set MOCK_DNF_LOG to record invocations.
+# Set MOCK_DNF_UPGRADE_EXIT (default 0) to control 'upgrade'
+# Set MOCK_DNF_INSTALL_EXIT (default 0) to control 'install'
+# Set MOCK_DNF_REMOVE_EXIT  (default 0) to control 'remove'
+# Set MOCK_DNF_EXIT         (default 0) for all other subcommands
+echo "dnf $*" >> "${MOCK_DNF_LOG:-/dev/null}"
+case "$*" in
+    *upgrade*) exit "${MOCK_DNF_UPGRADE_EXIT:-0}" ;;
+    *install*) exit "${MOCK_DNF_INSTALL_EXIT:-0}" ;;
+    *remove*)  exit "${MOCK_DNF_REMOVE_EXIT:-0}" ;;
+    *)         exit "${MOCK_DNF_EXIT:-0}" ;;
+esac

--- a/tests/mocks/rpm
+++ b/tests/mocks/rpm
@@ -1,0 +1,10 @@
+#!/bin/bash
+# tests/mocks/rpm — Configurable stub for package query.
+# Set MOCK_RPM_LOG to record invocations.
+# Set MOCK_RPM_Q_EXIT (default 0) to control -q (is_package_installed)
+# Set MOCK_RPM_EXIT  (default 0) for all other subcommands
+echo "rpm $*" >> "${MOCK_RPM_LOG:-/dev/null}"
+case "$*" in
+    *-q*) exit "${MOCK_RPM_Q_EXIT:-0}" ;;
+    *)    exit "${MOCK_RPM_EXIT:-0}" ;;
+esac

--- a/tests/test_detect.bats
+++ b/tests/test_detect.bats
@@ -63,3 +63,42 @@ teardown() {
     mapfile -t items < <(_state_read_list "nss_databases")
     [ "${#items[@]}" -eq 0 ]
 }
+
+@test "detect_required_tools succeeds even when certutil is absent from PATH" {
+    # certutil/modutil are installed by the packages phase, not a preflight requirement.
+    # Removing them from PATH must result in a warning, not a fatal exit.
+    local no_cert_dir="$BATS_TMPDIR/no_certutil"
+    mkdir -p "$no_cert_dir"
+    # Build a PATH that has all required system tools except certutil/modutil
+    local filtered_path
+    filtered_path="$(echo "$PATH" | tr ':' '\n' | grep -v "mocks" | tr '\n' ':' | sed 's/:$//')"
+    PATH="$no_cert_dir:$filtered_path" run detect_required_tools
+    [ "$status" -eq 0 ]
+}
+
+@test "detect_selinux is a no-op when getenforce is absent from PATH" {
+    local no_selinux_dir="$BATS_TMPDIR/no_selinux"
+    mkdir -p "$no_selinux_dir"
+    PATH="$no_selinux_dir" run detect_selinux
+    [ "$status" -eq 0 ]
+}
+
+@test "detect_selinux logs warning when SELinux is Enforcing" {
+    local mock_dir="$BATS_TMPDIR/selinux_mock"
+    mkdir -p "$mock_dir"
+    printf '#!/bin/bash\necho "Enforcing"\n' > "$mock_dir/getenforce"
+    chmod +x "$mock_dir/getenforce"
+    PATH="$mock_dir:$PATH" run detect_selinux
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"SELinux is Enforcing"* ]]
+}
+
+@test "detect_selinux logs info when SELinux is Permissive" {
+    local mock_dir="$BATS_TMPDIR/selinux_permissive"
+    mkdir -p "$mock_dir"
+    printf '#!/bin/bash\necho "Permissive"\n' > "$mock_dir/getenforce"
+    chmod +x "$mock_dir/getenforce"
+    PATH="$mock_dir:$PATH" run detect_selinux
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Permissive"* ]]
+}

--- a/tests/test_orchestrator/test_build_env_redhat.py
+++ b/tests/test_orchestrator/test_build_env_redhat.py
@@ -1,0 +1,108 @@
+"""tests/test_orchestrator/test_build_env_redhat.py — Tests for _build_env() with RedHatDriver."""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from distros.base import DistroInfo
+from distros.redhat.driver import RedHatDriver
+from orchestrator.setup_flow import _build_env
+from orchestrator.state import InstallState
+
+
+class TestBuildEnvRedHat(unittest.TestCase):
+    def setUp(self):
+        info = DistroInfo(distro_id="fedora", arch="x86_64")
+        self.driver = RedHatDriver(info)
+        self.state = InstallState(real_user="testuser")
+
+    def test_opensc_conf_injected_as_flat_path(self):
+        env = _build_env(self.driver, "testuser", self.state)
+        self.assertEqual(env["OPENSC_CONF"], "/etc/opensc.conf")
+
+    def test_has_aur_is_zero_for_red_hat(self):
+        env = _build_env(self.driver, "testuser", self.state)
+        self.assertEqual(env["HAS_AUR"], "0")
+
+    def test_pkg_query_cmd_uses_rpm(self):
+        env = _build_env(self.driver, "testuser", self.state)
+        self.assertIn("rpm", env["PKG_QUERY_CMD"])
+
+    def test_pkg_sync_cmd_uses_dnf_upgrade(self):
+        env = _build_env(self.driver, "testuser", self.state)
+        self.assertIn("dnf", env["PKG_SYNC_CMD"])
+        self.assertIn("upgrade", env["PKG_SYNC_CMD"])
+
+    def test_pkg_install_prefix_uses_dnf_install(self):
+        env = _build_env(self.driver, "testuser", self.state)
+        self.assertIn("dnf", env["PKG_INSTALL_PREFIX"])
+        self.assertIn("install", env["PKG_INSTALL_PREFIX"])
+
+    def test_pkg_remove_prefix_uses_dnf_remove(self):
+        env = _build_env(self.driver, "testuser", self.state)
+        self.assertIn("dnf", env["PKG_REMOVE_PREFIX"])
+        self.assertIn("remove", env["PKG_REMOVE_PREFIX"])
+
+    def test_required_packages_env_contains_nss_tools(self):
+        env = _build_env(self.driver, "testuser", self.state)
+        self.assertIn("nss-tools", env["REQUIRED_PACKAGES_ENV"])
+
+    def test_required_packages_env_contains_pcsc_lite(self):
+        env = _build_env(self.driver, "testuser", self.state)
+        self.assertIn("pcsc-lite", env["REQUIRED_PACKAGES_ENV"])
+
+    def test_smart_card_packages_env_set(self):
+        env = _build_env(self.driver, "testuser", self.state)
+        self.assertIn("SMART_CARD_PACKAGES_ENV", env)
+        self.assertIn("pcsc-lite", env["SMART_CARD_PACKAGES_ENV"])
+
+    def test_pkcs11_lib_injected(self):
+        env = _build_env(self.driver, "testuser", self.state)
+        self.assertEqual(env["PKCS11_LIB"], "/usr/lib64/opensc-pkcs11.so")
+
+
+class TestBuildEnvArch(unittest.TestCase):
+    """Regression: existing Arch env vars still injected correctly after refactor."""
+
+    class _ArchFakeDriver:
+        pkcs11_lib_path = "/usr/lib/opensc-pkcs11.so"
+        pcscd_unit = "pcscd.socket"
+        opensc_conf_path = "/etc/opensc/opensc.conf"
+        has_aur = True
+        package_manager = "pacman"
+        required_packages = ["pcsclite", "opensc"]
+        smart_card_packages = ["pcsclite", "opensc"]
+
+        def install_packages(self, packages):
+            return ["pacman", "-S", "--needed", "--noconfirm", *packages]
+
+        def remove_packages(self, packages):
+            return ["pacman", "-Rns", "--noconfirm", *packages]
+
+        def sync_package_db(self):
+            return ["pacman", "-Syu", "--noconfirm"]
+
+    def test_arch_has_aur_is_one(self):
+        state = InstallState(real_user="testuser")
+        env = _build_env(self._ArchFakeDriver(), "testuser", state)
+        self.assertEqual(env["HAS_AUR"], "1")
+
+    def test_arch_opensc_conf_uses_subdirectory(self):
+        state = InstallState(real_user="testuser")
+        env = _build_env(self._ArchFakeDriver(), "testuser", state)
+        self.assertEqual(env["OPENSC_CONF"], "/etc/opensc/opensc.conf")
+
+    def test_arch_pkg_query_cmd_uses_pacman(self):
+        state = InstallState(real_user="testuser")
+        env = _build_env(self._ArchFakeDriver(), "testuser", state)
+        self.assertIn("pacman", env["PKG_QUERY_CMD"])
+
+    def test_arch_pkg_sync_cmd_uses_syu(self):
+        state = InstallState(real_user="testuser")
+        env = _build_env(self._ArchFakeDriver(), "testuser", state)
+        self.assertIn("-Syu", env["PKG_SYNC_CMD"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orchestrator/test_build_env_redhat.py
+++ b/tests/test_orchestrator/test_build_env_redhat.py
@@ -29,10 +29,10 @@ class TestBuildEnvRedHat(unittest.TestCase):
         env = _build_env(self.driver, "testuser", self.state)
         self.assertIn("rpm", env["PKG_QUERY_CMD"])
 
-    def test_pkg_sync_cmd_uses_dnf_upgrade(self):
+    def test_pkg_sync_cmd_uses_dnf_makecache(self):
         env = _build_env(self.driver, "testuser", self.state)
         self.assertIn("dnf", env["PKG_SYNC_CMD"])
-        self.assertIn("upgrade", env["PKG_SYNC_CMD"])
+        self.assertIn("makecache", env["PKG_SYNC_CMD"])
 
     def test_pkg_install_prefix_uses_dnf_install(self):
         env = _build_env(self.driver, "testuser", self.state)

--- a/tests/test_orchestrator/test_build_env_redhat.py
+++ b/tests/test_orchestrator/test_build_env_redhat.py
@@ -29,10 +29,9 @@ class TestBuildEnvRedHat(unittest.TestCase):
         env = _build_env(self.driver, "testuser", self.state)
         self.assertIn("rpm", env["PKG_QUERY_CMD"])
 
-    def test_pkg_sync_cmd_uses_dnf_makecache(self):
+    def test_pkg_sync_cmd_is_noop(self):
         env = _build_env(self.driver, "testuser", self.state)
-        self.assertIn("dnf", env["PKG_SYNC_CMD"])
-        self.assertIn("makecache", env["PKG_SYNC_CMD"])
+        self.assertEqual(env["PKG_SYNC_CMD"], "true")
 
     def test_pkg_install_prefix_uses_dnf_install(self):
         env = _build_env(self.driver, "testuser", self.state)

--- a/tests/test_orchestrator/test_distro_detect.py
+++ b/tests/test_orchestrator/test_distro_detect.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from distros.arch.driver import ArchDriver
+from distros.redhat.driver import RedHatDriver
 from distros.detect import OS_RELEASE_PATH, detect_distro
 
 
@@ -34,6 +35,33 @@ _UNKNOWN_OS_RELEASE = """\
 NAME="FictionalOS"
 ID=fictionalos
 PRETTY_NAME="FictionalOS 1.0"
+"""
+
+_FEDORA_OS_RELEASE = """\
+NAME="Fedora Linux"
+ID=fedora
+PRETTY_NAME="Fedora Linux 40 (Workstation Edition)"
+"""
+
+_RHEL_OS_RELEASE = """\
+NAME="Red Hat Enterprise Linux"
+ID=rhel
+ID_LIKE=fedora
+PRETTY_NAME="Red Hat Enterprise Linux 9.3 (Plow)"
+"""
+
+_ROCKY_OS_RELEASE = """\
+NAME="Rocky Linux"
+ID=rocky
+ID_LIKE="rhel centos fedora"
+PRETTY_NAME="Rocky Linux 9.3 (Blue Onyx)"
+"""
+
+_ALMALINUX_OS_RELEASE = """\
+NAME="AlmaLinux"
+ID=almalinux
+ID_LIKE="rhel centos fedora"
+PRETTY_NAME="AlmaLinux OS 9.3 (Shamrock Pampas Cat)"
 """
 
 
@@ -92,6 +120,36 @@ class TestDetectDistro(unittest.TestCase):
             with patch("distros.detect.platform.machine", return_value="x86_64"):
                 info, _ = detect_distro()
         self.assertIn("arch", info.id_like)
+
+    # ── Red Hat family routing ──────────────────────────────────────────────
+
+    def test_fedora_returns_redhat_driver(self):
+        with patch.object(Path, "read_text", return_value=_FEDORA_OS_RELEASE):
+            with patch("distros.detect.platform.machine", return_value="x86_64"):
+                info, driver = detect_distro()
+        self.assertEqual(info.distro_id, "fedora")
+        self.assertIsInstance(driver, RedHatDriver)
+
+    def test_rhel_returns_redhat_driver(self):
+        with patch.object(Path, "read_text", return_value=_RHEL_OS_RELEASE):
+            with patch("distros.detect.platform.machine", return_value="x86_64"):
+                info, driver = detect_distro()
+        self.assertEqual(info.distro_id, "rhel")
+        self.assertIsInstance(driver, RedHatDriver)
+
+    def test_rocky_returns_redhat_driver(self):
+        with patch.object(Path, "read_text", return_value=_ROCKY_OS_RELEASE):
+            with patch("distros.detect.platform.machine", return_value="x86_64"):
+                info, driver = detect_distro()
+        self.assertEqual(info.distro_id, "rocky")
+        self.assertIsInstance(driver, RedHatDriver)
+
+    def test_almalinux_returns_redhat_driver(self):
+        with patch.object(Path, "read_text", return_value=_ALMALINUX_OS_RELEASE):
+            with patch("distros.detect.platform.machine", return_value="x86_64"):
+                info, driver = detect_distro()
+        self.assertEqual(info.distro_id, "almalinux")
+        self.assertIsInstance(driver, RedHatDriver)
 
 
 if __name__ == "__main__":

--- a/tests/test_orchestrator/test_redhat_driver.py
+++ b/tests/test_orchestrator/test_redhat_driver.py
@@ -69,10 +69,10 @@ class TestRedHatDriver(unittest.TestCase):
         self.assertIn("remove", cmd)
         self.assertIn("opensc", cmd)
 
-    def test_sync_package_db_uses_dnf_upgrade(self):
+    def test_sync_package_db_uses_dnf_makecache(self):
         cmd = self.driver.sync_package_db()
         self.assertIn("dnf", cmd)
-        self.assertIn("upgrade", cmd)
+        self.assertIn("makecache", cmd)
 
     def test_firefox_profile_root_is_standard_mozilla_path(self):
         roots = self.driver.firefox_profile_roots

--- a/tests/test_orchestrator/test_redhat_driver.py
+++ b/tests/test_orchestrator/test_redhat_driver.py
@@ -1,0 +1,92 @@
+"""tests/test_orchestrator/test_redhat_driver.py — Unit tests for RedHatDriver."""
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from distros.base import DistroInfo
+from distros.redhat.driver import RedHatDriver
+
+
+class TestRedHatDriver(unittest.TestCase):
+    def setUp(self):
+        self.info = DistroInfo(
+            distro_id="fedora",
+            id_like=[],
+            arch="x86_64",
+            pretty_name="Fedora Linux 40 (Workstation Edition)",
+        )
+        self.driver = RedHatDriver(self.info)
+
+    def test_package_manager_is_dnf(self):
+        self.assertEqual(self.driver.package_manager, "dnf")
+
+    def test_pkcs11_lib_path_uses_lib64(self):
+        self.assertIn("lib64", self.driver.pkcs11_lib_path)
+        self.assertEqual(self.driver.pkcs11_lib_path, "/usr/lib64/opensc-pkcs11.so")
+
+    def test_opensc_conf_path_is_flat(self):
+        # Fedora opensc RPM ships /etc/opensc.conf, not /etc/opensc/opensc.conf
+        self.assertEqual(self.driver.opensc_conf_path, "/etc/opensc.conf")
+        self.assertNotIn("/opensc/", self.driver.opensc_conf_path)
+
+    def test_has_aur_is_false(self):
+        self.assertFalse(self.driver.has_aur)
+
+    def test_pcscd_unit_is_socket(self):
+        self.assertEqual(self.driver.pcscd_unit, "pcscd.socket")
+
+    def test_required_packages_contains_nss_tools(self):
+        # Fedora: nss-tools provides certutil/modutil (not 'nss' as on Arch)
+        self.assertIn("nss-tools", self.driver.required_packages)
+        self.assertNotIn("nss", self.driver.required_packages)
+
+    def test_required_packages_contains_pcsc_lite_with_hyphen(self):
+        # Fedora uses pcsc-lite (hyphen), not pcsclite (no hyphen) as on Arch
+        self.assertIn("pcsc-lite", self.driver.required_packages)
+        self.assertNotIn("pcsclite", self.driver.required_packages)
+
+    def test_smart_card_packages_contains_pcsc_lite(self):
+        self.assertIn("pcsc-lite", self.driver.smart_card_packages)
+        self.assertNotIn("pcsclite", self.driver.smart_card_packages)
+
+    def test_install_packages_uses_dnf(self):
+        cmd = self.driver.install_packages(["opensc", "ccid"])
+        self.assertEqual(cmd[0], "dnf")
+        self.assertIn("install", cmd)
+        self.assertIn("opensc", cmd)
+        self.assertIn("ccid", cmd)
+
+    def test_install_packages_empty_list_is_valid_prefix(self):
+        # install_packages([]) must return a valid command prefix (no trailing args)
+        cmd = self.driver.install_packages([])
+        self.assertEqual(cmd, ["dnf", "install", "-y"])
+
+    def test_remove_packages_uses_dnf(self):
+        cmd = self.driver.remove_packages(["opensc"])
+        self.assertEqual(cmd[0], "dnf")
+        self.assertIn("remove", cmd)
+        self.assertIn("opensc", cmd)
+
+    def test_sync_package_db_uses_dnf_upgrade(self):
+        cmd = self.driver.sync_package_db()
+        self.assertIn("dnf", cmd)
+        self.assertIn("upgrade", cmd)
+
+    def test_firefox_profile_root_is_standard_mozilla_path(self):
+        roots = self.driver.firefox_profile_roots
+        self.assertIn(".mozilla/firefox", roots)
+        # Fedora does NOT have the CachyOS variant
+        self.assertNotIn(".config/mozilla/firefox", roots)
+
+    def test_required_packages_returns_new_list_each_call(self):
+        # Must return a copy, not the internal list (mutation safety)
+        pkgs1 = self.driver.required_packages
+        pkgs1.append("__sentinel__")
+        pkgs2 = self.driver.required_packages
+        self.assertNotIn("__sentinel__", pkgs2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_orchestrator/test_redhat_driver.py
+++ b/tests/test_orchestrator/test_redhat_driver.py
@@ -69,10 +69,9 @@ class TestRedHatDriver(unittest.TestCase):
         self.assertIn("remove", cmd)
         self.assertIn("opensc", cmd)
 
-    def test_sync_package_db_uses_dnf_makecache(self):
+    def test_sync_package_db_is_noop(self):
         cmd = self.driver.sync_package_db()
-        self.assertIn("dnf", cmd)
-        self.assertIn("makecache", cmd)
+        self.assertEqual(cmd, ["true"])
 
     def test_firefox_profile_root_is_standard_mozilla_path(self):
         roots = self.driver.firefox_profile_roots

--- a/tests/test_orchestrator/test_setup_flow.py
+++ b/tests/test_orchestrator/test_setup_flow.py
@@ -57,10 +57,24 @@ class TestBuildEnvNssDbPaths(unittest.TestCase):
     class _FakeDriver:
         pkcs11_lib_path = "/usr/lib/opensc-pkcs11.so"
         pcscd_unit = "pcscd.socket"
+        opensc_conf_path = "/etc/opensc/opensc.conf"
+        has_aur = True
+        package_manager = "pacman"
+        required_packages = ["pcsclite", "opensc"]
+        smart_card_packages = ["pcsclite", "opensc"]
 
         class distro_info:
             distro_id = "cachyos"
             arch = "x86_64"
+
+        def install_packages(self, packages):
+            return ["pacman", "-S", "--needed", "--noconfirm", *packages]
+
+        def remove_packages(self, packages):
+            return ["pacman", "-Rns", "--noconfirm", *packages]
+
+        def sync_package_db(self):
+            return ["pacman", "-Syu", "--noconfirm"]
 
     def test_nss_db_paths_included_when_state_has_databases(self):
         state = InstallState(

--- a/tests/test_packages.bats
+++ b/tests/test_packages.bats
@@ -78,7 +78,7 @@ _setup_redhat_env() {
     # Unset Arch-specific arrays so packages.sh re-reads from env vars.
     unset REQUIRED_PACKAGES SMART_CARD_PACKAGES_LIST
     export PKG_QUERY_CMD="rpm -q"
-    export PKG_SYNC_CMD="dnf makecache"
+    export PKG_SYNC_CMD="true"
     export PKG_INSTALL_PREFIX="dnf install -y"
     export PKG_REMOVE_PREFIX="dnf remove -y"
     export REQUIRED_PACKAGES_ENV="pcsc-lite ccid opensc nss-tools"
@@ -100,10 +100,12 @@ _setup_redhat_env() {
     [ "$status" -ne 0 ]
 }
 
-@test "install_official_packages invokes dnf makecache when PKG_SYNC_CMD is set" {
+@test "install_official_packages skips dnf sync when PKG_SYNC_CMD is true" {
     _setup_redhat_env
+    # All packages already installed — only the sync step would normally run.
+    # With PKG_SYNC_CMD="true", no dnf call should appear in the log.
     MOCK_RPM_Q_EXIT=0 install_official_packages
-    grep -q "dnf makecache" "$MOCK_DNF_LOG"
+    [ ! -f "$MOCK_DNF_LOG" ] || [ ! -s "$MOCK_DNF_LOG" ]
 }
 
 @test "install_official_packages invokes dnf install for missing packages" {

--- a/tests/test_packages.bats
+++ b/tests/test_packages.bats
@@ -16,6 +16,8 @@ teardown() {
     rm -f "$_CAC_LOG_FILE"
 }
 
+# ── Arch / pacman path (default fallback) ─────────────────────────────────────
+
 @test "is_package_installed returns 0 when pacman -Qi succeeds" {
     MOCK_PACMAN_QI_EXIT=0 run is_package_installed "opensc"
     [ "$status" -eq 0 ]
@@ -57,13 +59,69 @@ teardown() {
     printf '{"packages_installed":["pcsclite=1.0","opensc=1.0"]}\n' > "$STATE_FILE"
     # Mock pacman -Qi returns 0 (packages still present)
     MOCK_PACMAN_QI_EXIT=0 remove_smart_card_packages
-    grep -q "\-Rs" "$MOCK_PACMAN_LOG"
+    # PKG_REMOVE_PREFIX defaults to "pacman -Rns --noconfirm"
+    grep -q "pacman -Rns" "$MOCK_PACMAN_LOG"
 }
 
 @test "remove_smart_card_packages skips general packages (wget, unzip)" {
     printf '{"packages_installed":["wget=1.0","unzip=1.0"]}\n' > "$STATE_FILE"
     MOCK_PACMAN_QI_EXIT=0 remove_smart_card_packages
-    # No -Rs call expected since none are in smart_card_only
-    ! grep -q "\-Rs" "$MOCK_PACMAN_LOG" 2>/dev/null
+    # No pacman -Rns call expected since none are in SMART_CARD_PACKAGES_LIST
+    ! grep -q "pacman -Rns" "$MOCK_PACMAN_LOG" 2>/dev/null
     true
+}
+
+# ── Red Hat / dnf path (via env var injection) ────────────────────────────────
+
+_setup_redhat_env() {
+    # Simulate the env vars Python injects for Red Hat systems.
+    # Unset Arch-specific arrays so packages.sh re-reads from env vars.
+    unset REQUIRED_PACKAGES SMART_CARD_PACKAGES_LIST
+    export PKG_QUERY_CMD="rpm -q"
+    export PKG_SYNC_CMD="dnf upgrade -y"
+    export PKG_INSTALL_PREFIX="dnf install -y"
+    export PKG_REMOVE_PREFIX="dnf remove -y"
+    export REQUIRED_PACKAGES_ENV="pcsc-lite ccid opensc nss-tools"
+    export SMART_CARD_PACKAGES_ENV="pcsc-lite ccid opensc pcsc-lite-utils"
+    # Re-source packages.sh so it picks up the new env vars
+    _source_lib "packages"
+}
+
+@test "is_package_installed uses rpm -q when PKG_QUERY_CMD is set" {
+    _setup_redhat_env
+    MOCK_RPM_Q_EXIT=0 run is_package_installed "opensc"
+    [ "$status" -eq 0 ]
+    grep -q "rpm -q opensc" "$MOCK_RPM_LOG"
+}
+
+@test "is_package_installed returns non-zero via rpm -q when package missing" {
+    _setup_redhat_env
+    MOCK_RPM_Q_EXIT=1 run is_package_installed "missing-pkg"
+    [ "$status" -ne 0 ]
+}
+
+@test "install_official_packages invokes dnf upgrade when PKG_SYNC_CMD is set" {
+    _setup_redhat_env
+    MOCK_RPM_Q_EXIT=0 install_official_packages
+    grep -q "dnf upgrade" "$MOCK_DNF_LOG"
+}
+
+@test "install_official_packages invokes dnf install for missing packages" {
+    _setup_redhat_env
+    MOCK_RPM_Q_EXIT=1 install_official_packages
+    grep -q "dnf install" "$MOCK_DNF_LOG"
+}
+
+@test "install_official_packages uses REQUIRED_PACKAGES_ENV package list" {
+    _setup_redhat_env
+    MOCK_RPM_Q_EXIT=1 install_official_packages
+    # pcsc-lite is from the Red Hat list (not pcsclite which is Arch)
+    grep -q "pcsc-lite" "$MOCK_DNF_LOG"
+}
+
+@test "remove_smart_card_packages invokes dnf remove when PKG_REMOVE_PREFIX is set" {
+    _setup_redhat_env
+    printf '{"packages_installed":["pcsc-lite=1.0","opensc=1.0"]}\n' > "$STATE_FILE"
+    MOCK_RPM_Q_EXIT=0 remove_smart_card_packages
+    grep -q "dnf remove" "$MOCK_DNF_LOG"
 }

--- a/tests/test_packages.bats
+++ b/tests/test_packages.bats
@@ -78,7 +78,7 @@ _setup_redhat_env() {
     # Unset Arch-specific arrays so packages.sh re-reads from env vars.
     unset REQUIRED_PACKAGES SMART_CARD_PACKAGES_LIST
     export PKG_QUERY_CMD="rpm -q"
-    export PKG_SYNC_CMD="dnf upgrade -y"
+    export PKG_SYNC_CMD="dnf makecache"
     export PKG_INSTALL_PREFIX="dnf install -y"
     export PKG_REMOVE_PREFIX="dnf remove -y"
     export REQUIRED_PACKAGES_ENV="pcsc-lite ccid opensc nss-tools"
@@ -100,10 +100,10 @@ _setup_redhat_env() {
     [ "$status" -ne 0 ]
 }
 
-@test "install_official_packages invokes dnf upgrade when PKG_SYNC_CMD is set" {
+@test "install_official_packages invokes dnf makecache when PKG_SYNC_CMD is set" {
     _setup_redhat_env
     MOCK_RPM_Q_EXIT=0 install_official_packages
-    grep -q "dnf upgrade" "$MOCK_DNF_LOG"
+    grep -q "dnf makecache" "$MOCK_DNF_LOG"
 }
 
 @test "install_official_packages invokes dnf install for missing packages" {

--- a/tests/test_packages.bats
+++ b/tests/test_packages.bats
@@ -82,7 +82,7 @@ _setup_redhat_env() {
     export PKG_INSTALL_PREFIX="dnf install -y"
     export PKG_REMOVE_PREFIX="dnf remove -y"
     export REQUIRED_PACKAGES_ENV="pcsc-lite ccid opensc nss-tools"
-    export SMART_CARD_PACKAGES_ENV="pcsc-lite ccid opensc pcsc-lite-utils"
+    export SMART_CARD_PACKAGES_ENV="pcsc-lite ccid opensc pcsc-tools"
     # Re-source packages.sh so it picks up the new env vars
     _source_lib "packages"
 }


### PR DESCRIPTION
## Summary

- Adds `distros/redhat/` driver + config targeting Fedora, RHEL, CentOS Stream, Rocky Linux, and AlmaLinux (user will test with Fedora)
- Generalises `lib/packages.sh` away from hardcoded `pacman` via 8 injected env vars (`PKG_QUERY_CMD`, `PKG_SYNC_CMD`, `PKG_INSTALL_PREFIX`, `PKG_REMOVE_PREFIX`, `REQUIRED_PACKAGES_ENV`, `SMART_CARD_PACKAGES_ENV`, `OPENSC_CONF`, `HAS_AUR`); all vars fall back to Arch defaults for standalone developer use
- Adds two new abstract properties to `DistroDriver` ABC: `opensc_conf_path` and `has_aur`
- Fixes preflight `certutil`/`modutil` check to warn rather than fatally exit on distros where `nss-tools` isn't pre-installed
- Adds `detect_selinux()` informational warning for SELinux-enforcing systems (Fedora default)
- Guards AUR helper detection behind `HAS_AUR` flag in `bash/install.sh`
- Documents six Fedora-specific known issues (FN1–FN6) in `KNOWN_ISSUES.md`

## Key Fedora differences handled

| Concern | Arch | Fedora |
|---|---|---|
| Package manager | `pacman` | `dnf` |
| PKCS11 lib path | `/usr/lib/opensc-pkcs11.so` | `/usr/lib64/opensc-pkcs11.so` |
| opensc.conf path | `/etc/opensc/opensc.conf` | `/etc/opensc.conf` |
| certutil package | `nss` | `nss-tools` |
| pcsclite package | `pcsclite` | `pcsc-lite` |
| AUR support | Yes | No |
| SELinux | Absent | Enforcing by default |

## Test plan

- [ ] All 102 Python unit tests pass (`python -m unittest discover -s tests/test_orchestrator -v`)
- [ ] All 92 BATS tests pass (`bats tests/*.bats`)
- [ ] `shellcheck -x lib/*.sh bash/*.sh` clean
- [ ] `ruff check orchestrator/ distros/ *.py` clean
- [ ] Integration test on Fedora VM: `sudo python3 cac_setup.py`
- [ ] Verify `pkcs11-tool --list-readers` and `certutil -L -d ~/.pki/nssdb` show expected output
- [ ] Verify `pcsc-lite-utils` package name with `dnf provides pcsc_scan` before finalising `config.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)